### PR TITLE
Add Chapter 2 best-predictor and linear-projection results

### DIFF
--- a/HansenEconometrics/Chapter2CondExp.lean
+++ b/HansenEconometrics/Chapter2CondExp.lean
@@ -132,4 +132,115 @@ theorem integral_mul_cefError_zero
     simp [hω])]
   simp
 
+/-- Conditional expectation in `L²` is the orthogonal projection onto the space of
+`m`-measurable square-integrable functions, hence it minimizes `L²` distance. -/
+theorem condExpL2_minimal
+    {Y g : Ω → ℝ}
+    (hm : m ≤ m₀)
+    [IsFiniteMeasure μ]
+    (hY : MemLp Y 2 μ)
+    (hg : MemLp g 2 μ)
+    (hg_m : AEStronglyMeasurable[m] g μ) :
+    ‖hY.toLp Y - (MeasureTheory.condExpL2 ℝ ℝ hm (hY.toLp Y) : Ω →₂[μ] ℝ)‖ ≤
+      ‖hY.toLp Y - hg.toLp g‖ := by
+  haveI : Fact (m ≤ m₀) := ⟨hm⟩
+  haveI : Fact (1 ≤ (2 : ℝ≥0∞)) := ⟨by norm_num⟩
+  let g_m_lp : MeasureTheory.lpMeas ℝ ℝ m 2 μ :=
+    ⟨hg.toLp g,
+      MeasureTheory.mem_lpMeas_iff_aestronglyMeasurable.mpr <|
+        AEStronglyMeasurable.congr hg_m (MemLp.coeFn_toLp hg).symm⟩
+  calc
+    ‖hY.toLp Y - (MeasureTheory.condExpL2 ℝ ℝ hm (hY.toLp Y) : Ω →₂[μ] ℝ)‖ =
+        ‖hY.toLp Y - (MeasureTheory.lpMeas ℝ ℝ m 2 μ).starProjection (hY.toLp Y)‖ := by
+          rfl
+    _ = ⨅ x : MeasureTheory.lpMeas ℝ ℝ m 2 μ, ‖hY.toLp Y - x‖ := by
+          simpa [MeasureTheory.condExpL2]
+            using
+              (Submodule.starProjection_minimal
+                (U := MeasureTheory.lpMeas ℝ ℝ m 2 μ) (y := hY.toLp Y))
+    _ ≤ ‖hY.toLp Y - g_m_lp‖ := by
+          have h_bdd :
+              BddBelow (Set.range
+                (fun x : MeasureTheory.lpMeas ℝ ℝ m 2 μ => ‖hY.toLp Y - x‖)) := by
+            refine ⟨0, ?_⟩
+            rintro y ⟨x, rfl⟩
+            exact norm_nonneg _
+          simpa using
+            (ciInf_le h_bdd g_m_lp)
+    _ = ‖hY.toLp Y - hg.toLp g‖ := by
+          rfl
+
+/-- Hansen Theorem 2.7 in sigma-algebra form: the conditional mean minimizes mean squared
+prediction error among `m`-measurable square-integrable predictors. -/
+theorem integral_sq_sub_condExp_le_integral_sq_sub
+    {Y g : Ω → ℝ}
+    (hm : m ≤ m₀)
+    [SigmaFinite (μ.trim hm)]
+    [IsFiniteMeasure μ]
+    (hY : MemLp Y 2 μ)
+    (hg : MemLp g 2 μ)
+    (hg_m : AEStronglyMeasurable[m] g μ) :
+    ∫ ω, (Y ω - (μ[Y | m]) ω) ^ 2 ∂μ ≤ ∫ ω, (Y ω - g ω) ^ 2 ∂μ := by
+  let d : Ω → ℝ := fun ω => (μ[Y | m]) ω - g ω
+  have hY_int : Integrable Y μ :=
+    memLp_one_iff_integrable.1 <| hY.mono_exponent one_le_two
+  have hd_m : AEStronglyMeasurable[m] d μ := by
+    exact stronglyMeasurable_condExp.aestronglyMeasurable.sub hg_m
+  have he2 : Integrable (fun ω => (cefError (μ := μ) Y m ω) ^ 2) μ := by
+    simpa [cefError] using (hY.sub hY.condExp).integrable_sq
+  have hd2 : Integrable (fun ω => (d ω) ^ 2) μ := by
+    exact (hY.condExp.sub hg).integrable_sq
+  have hde : Integrable (fun ω => d ω * cefError (μ := μ) Y m ω) μ := by
+    simpa [cefError, d] using
+      memLp_one_iff_integrable.1 <| (hY.sub hY.condExp).mul (hY.condExp.sub hg)
+  have horth :
+      ∫ ω, d ω * cefError (μ := μ) Y m ω ∂μ = 0 :=
+    integral_mul_cefError_zero (m := m) (m₀ := m₀) (μ := μ) (g := d) (Y := Y) hm hd_m hde hY_int
+  have h_expand :
+      (fun ω => (Y ω - g ω) ^ 2) =ᵐ[μ]
+        fun ω =>
+          (cefError (μ := μ) Y m ω) ^ 2 + (d ω) ^ 2 +
+            2 * (d ω * cefError (μ := μ) Y m ω) := by
+    filter_upwards [] with ω
+    dsimp [cefError, d]
+    ring
+  have hnonneg : 0 ≤ ∫ ω, (d ω) ^ 2 ∂μ := by
+    refine integral_nonneg ?_
+    intro ω
+    exact sq_nonneg _
+  calc
+    ∫ ω, (Y ω - (μ[Y | m]) ω) ^ 2 ∂μ
+        = ∫ ω, (cefError (μ := μ) Y m ω) ^ 2 ∂μ := by
+            simp [cefError]
+    _ ≤ ∫ ω, (cefError (μ := μ) Y m ω) ^ 2 ∂μ + ∫ ω, (d ω) ^ 2 ∂μ := by
+          linarith
+    _ = ∫ ω, (cefError (μ := μ) Y m ω) ^ 2 + (d ω) ^ 2 ∂μ := by
+          rw [integral_add he2 hd2]
+    _ = ∫ ω, (cefError (μ := μ) Y m ω) ^ 2 + (d ω) ^ 2 ∂μ +
+          ∫ ω, 2 * (d ω * cefError (μ := μ) Y m ω) ∂μ := by
+          rw [integral_const_mul, horth]
+          ring
+    _ = ∫ ω, (cefError (μ := μ) Y m ω) ^ 2 + (d ω) ^ 2 +
+          2 * (d ω * cefError (μ := μ) Y m ω) ∂μ := by
+          simpa [add_assoc] using
+            (integral_add (he2.add hd2) (hde.const_mul 2)).symm
+    _ = ∫ ω, (Y ω - g ω) ^ 2 ∂μ := by
+          rw [integral_congr_ae h_expand.symm]
+
+/-- Hansen Theorem 2.7 written as `E[Y | X]` minimizes mean squared prediction error among
+predictors measurable with respect to `X`. -/
+theorem integral_sq_sub_condExp_le_integral_sq_sub_X
+    {Y g : Ω → ℝ} {X : Ω → β}
+    (hX : Measurable X)
+    [SigmaFinite (μ.trim hX.comap_le)]
+    [IsFiniteMeasure μ]
+    (hY : MemLp Y 2 μ)
+    (hg : MemLp g 2 μ)
+    (hg_X : AEStronglyMeasurable[mβ.comap X] g μ) :
+    ∫ ω, (Y ω - (μ[Y | mβ.comap X]) ω) ^ 2 ∂μ ≤ ∫ ω, (Y ω - g ω) ^ 2 ∂μ := by
+  simpa using
+    (integral_sq_sub_condExp_le_integral_sq_sub
+      (m := mβ.comap X) (m₀ := m₀) (μ := μ) (Y := Y) (g := g)
+      hX.comap_le hY hg hg_X)
+
 end HansenEconometrics

--- a/HansenEconometrics/Chapter2LinearProjection.lean
+++ b/HansenEconometrics/Chapter2LinearProjection.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import HansenEconometrics.Basic
+import HansenEconometrics.LinearAlgebraUtils
 
 open scoped Matrix
 
@@ -55,5 +56,81 @@ theorem linearProjectionMSE_at_beta
   unfold linearProjectionMSE
   rw [linearProjectionBeta_normal_equations]
   ring
+
+/-- Quadratic completion for the population projection criterion. This is the deterministic algebra
+behind the best-linear-predictor minimization statement. -/
+theorem linearProjectionMSE_eq_at_beta_add_quadratic_form
+    (QXX : Matrix k k ℝ) (QXY : k → ℝ) (QYY : ℝ) (b : k → ℝ)
+    [Invertible QXX]
+    (hQXXt : QXXᵀ = QXX) :
+    linearProjectionMSE QXX QXY QYY b =
+      linearProjectionMSE QXX QXY QYY (linearProjectionBeta QXX QXY) +
+        (b - linearProjectionBeta QXX QXY) ⬝ᵥ
+          (QXX *ᵥ (b - linearProjectionBeta QXX QXY)) := by
+  have hβ :
+      QXX *ᵥ linearProjectionBeta QXX QXY = QXY :=
+    linearProjectionBeta_normal_equations QXX QXY
+  have hsymm :
+      linearProjectionBeta QXX QXY ⬝ᵥ (QXX *ᵥ b) =
+        b ⬝ᵥ (QXX *ᵥ linearProjectionBeta QXX QXY) := by
+    calc
+      linearProjectionBeta QXX QXY ⬝ᵥ (QXX *ᵥ b) =
+          Matrix.vecMul (linearProjectionBeta QXX QXY) QXX ⬝ᵥ b := by
+        rw [Matrix.dotProduct_mulVec]
+      _ = (QXX *ᵥ linearProjectionBeta QXX QXY) ⬝ᵥ b := by
+        rw [vecMul_eq_mulVec_of_transpose_eq_self QXX hQXXt]
+      _ = b ⬝ᵥ (QXX *ᵥ linearProjectionBeta QXX QXY) := by
+        rw [dotProduct_comm]
+  have hcross :
+      linearProjectionBeta QXX QXY ⬝ᵥ (QXX *ᵥ b) = b ⬝ᵥ QXY := by
+    rw [hsymm, hβ]
+  rw [linearProjectionMSE_at_beta]
+  unfold linearProjectionMSE
+  rw [Matrix.mulVec_sub, sub_dotProduct, dotProduct_sub, dotProduct_sub]
+  rw [hcross]
+  rw [hβ]
+  ring_nf
+
+/-- Hansen Definition 2.5 / Theorem 2.9: the projection coefficient minimizes the population
+linear-prediction mean squared error. -/
+theorem linearProjectionBeta_minimizes_MSE
+    (QXX : Matrix k k ℝ) (QXY : k → ℝ) (QYY : ℝ) [Invertible QXX]
+    (hQXXt : QXXᵀ = QXX)
+    (hQXX_nonneg : ∀ v : k → ℝ, 0 ≤ v ⬝ᵥ (QXX *ᵥ v))
+    (b : k → ℝ) :
+    linearProjectionMSE QXX QXY QYY (linearProjectionBeta QXX QXY) ≤
+      linearProjectionMSE QXX QXY QYY b := by
+  rw [linearProjectionMSE_eq_at_beta_add_quadratic_form QXX QXY QYY b hQXXt]
+  linarith [hQXX_nonneg (b - linearProjectionBeta QXX QXY)]
+
+/-- Hansen Theorem 2.9 in textbook moment notation: if `EXX = E[XXᵀ]`, `EXY = E[XY]`, and
+`EY2 = E[Y²]`, then `β = (EXX)⁻¹ EXY` minimizes the population linear-prediction criterion. -/
+theorem linearProjectionBeta_minimizes_MSE_of_moments
+    (EXX : Matrix k k ℝ) (EXY : k → ℝ) (EY2 : ℝ) [Invertible EXX]
+    (hEXXt : EXXᵀ = EXX)
+    (hEXX_nonneg : ∀ v : k → ℝ, 0 ≤ v ⬝ᵥ (EXX *ᵥ v))
+    (b : k → ℝ) :
+    linearProjectionMSE EXX EXY EY2 (linearProjectionBeta EXX EXY) ≤
+      linearProjectionMSE EXX EXY EY2 b := by
+  exact linearProjectionBeta_minimizes_MSE EXX EXY EY2 hEXXt hEXX_nonneg b
+
+/-- Under strict positive definiteness of the quadratic form, the projection coefficient is the
+unique minimizer of the population linear-prediction criterion. -/
+theorem linearProjectionBeta_eq_of_MSE_eq
+    (QXX : Matrix k k ℝ) (QXY : k → ℝ) (QYY : ℝ) (b : k → ℝ)
+    [Invertible QXX]
+    (hQXXt : QXXᵀ = QXX)
+    (hQXX_pos : ∀ v : k → ℝ, v ≠ 0 → 0 < v ⬝ᵥ (QXX *ᵥ v))
+    (hb : linearProjectionMSE QXX QXY QYY b =
+      linearProjectionMSE QXX QXY QYY (linearProjectionBeta QXX QXY)) :
+    b = linearProjectionBeta QXX QXY := by
+  by_contra hbne
+  have hneq : b - linearProjectionBeta QXX QXY ≠ 0 := sub_ne_zero.mpr hbne
+  have hpos :
+      0 < (b - linearProjectionBeta QXX QXY) ⬝ᵥ
+        (QXX *ᵥ (b - linearProjectionBeta QXX QXY)) :=
+    hQXX_pos (b - linearProjectionBeta QXX QXY) hneq
+  rw [linearProjectionMSE_eq_at_beta_add_quadratic_form QXX QXY QYY b hQXXt] at hb
+  linarith
 
 end HansenEconometrics

--- a/notes/ch02/theorem_inventory.md
+++ b/notes/ch02/theorem_inventory.md
@@ -59,12 +59,15 @@ Then prove:
   `QXY - QXX β = 0`
 - uniqueness from the normal equations
 - quadratic criterion simplification at `β`
+- quadratic completion:
+  `S(b) = S(β) + (b - β)' QXX (b - β)`
+- best-linear-predictor minimization statement
+- textbook moment wrapper:
+  `β = (E[XX'])⁻¹ E[XY]` minimizes the population criterion
 
 ## Later chapter targets (not yet formalized)
 - **T2.5** finite regression-error variance from `E[Y²] < ∞`
 - **T2.6** monotonic decrease of residual variance under larger conditioning sets
-- conditional expectation as best predictor
-- full best-linear-predictor minimization statement
 - finite-second-moment consequences
 
 ## Files


### PR DESCRIPTION
## What changed

This draft PR adds the next Chapter 2 formalization layer around prediction and projection.

- adds the conditional-mean minimization result in Chapter2CondExp
- adds the X-specialized corollary for the best-predictor theorem
- adds the quadratic-completion and minimization theorems for the linear projection criterion in Chapter2LinearProjection
- adds a textbook-moment wrapper for the linear-projection minimization statement
- updates the Chapter 2 theorem inventory to reflect the newly formalized results

## Why

These results fill two visible gaps in the Chapter 2 development:

- Hansen Theorem 2.7: conditional expectation as the best predictor under squared loss
- the core minimization statement behind Hansen Definition 2.5 / Theorem 2.9 for the best linear predictor

## Impact

The chapter now has both the sigma-algebra/native Lean versions and textbook-facing wrappers for the main prediction statements.

## Validation

- lake build HansenEconometrics.Chapter2CondExp
- lake build HansenEconometrics.Chapter2LinearProjection
- lake build

## Notes

This is a draft PR because the next natural follow-up is to keep building out the Chapter 2 linear-projection package from here.