### PR TITLE
Potential outcomes and thm 2.10

### DIFF
--- a/HansenEconometrics.lean
+++ b/HansenEconometrics.lean
@@ -7,6 +7,7 @@ import HansenEconometrics.Chapter2CondExp
 
 import HansenEconometrics.Chapter2LinearProjection
 import HansenEconometrics.Chapter2Variance
+import HansenEconometrics.Chapter2PotentialOutcomes
 import HansenEconometrics.Chapter3LeastSquaresAlgebra
 import HansenEconometrics.Chapter3Projections
 import HansenEconometrics.Chapter3FWL

--- a/HansenEconometrics/Chapter2LinearProjection.lean
+++ b/HansenEconometrics/Chapter2LinearProjection.lean
@@ -163,10 +163,10 @@ theorem linearProjectionIntercept_eq_mean_sub_dotProduct
     (hmodel : Y = fun ω => α + dotProduct (X ω) β + e ω)
     (he_zero : ∫ ω, e ω ∂μ = 0) :
     α = ∫ ω, Y ω ∂μ - meanVec μ X ⬝ᵥ β := by
+  classical
   have hX_int : ∀ i, Integrable (fun ω => X ω i) μ := fun i => hX i |>.integrable (by norm_num)
   have he_int : Integrable e μ := he.integrable (by norm_num)
   have hlin_int : Integrable (fun ω => dotProduct (X ω) β) μ := by
-    classical
     convert (MeasureTheory.integrable_finset_sum (s := Finset.univ) (f := fun j ω => X ω j * β j)
       (fun j _ => (hX_int j).mul_const (β j))) using 1
   have hmean :

--- a/HansenEconometrics/Chapter2PotentialOutcomes.lean
+++ b/HansenEconometrics/Chapter2PotentialOutcomes.lean
@@ -1,0 +1,169 @@
+import HansenEconometrics.Chapter2CondExp
+
+/-!
+# Chapter 2 Potential Outcomes
+
+This file starts the variable-facing potential-outcomes API for Hansen Section 2.30.
+The first public surface is stated as random-variable and almost-everywhere identities, matching the
+Chapter 2 probability layer. Pointwise regular-conditional-distribution versions of Theorem 2.12 can
+be built on top of this layer later.
+-/
+
+open scoped ENNReal Topology MeasureTheory ProbabilityTheory
+open MeasureTheory ProbabilityTheory
+
+namespace HansenEconometrics
+
+variable {Ω β : Type*}
+
+/-- Hansen Section 2.30 observed outcome for a binary treatment:
+`Y = Y(1)` on treated units and `Y = Y(0)` on untreated units. -/
+def observedOutcome (D : Ω → Bool) (Y0 Y1 : Ω → ℝ) : Ω → ℝ :=
+  fun ω => if D ω then Y1 ω else Y0 ω
+
+/-- Hansen Definition 2.6: individual treatment effect `Y(1) - Y(0)`. -/
+def treatmentEffect (Y0 Y1 : Ω → ℝ) : Ω → ℝ :=
+  fun ω => Y1 ω - Y0 ω
+
+@[simp] theorem observedOutcome_true (Y0 Y1 : Ω → ℝ) :
+    observedOutcome (fun _ => true) Y0 Y1 = Y1 := by
+  funext ω
+  simp [observedOutcome]
+
+@[simp] theorem observedOutcome_false (Y0 Y1 : Ω → ℝ) :
+    observedOutcome (fun _ => false) Y0 Y1 = Y0 := by
+  funext ω
+  simp [observedOutcome]
+
+@[simp] theorem observedOutcome_of_treated
+    {D : Ω → Bool} {Y0 Y1 : Ω → ℝ} {ω : Ω} (hD : D ω = true) :
+    observedOutcome D Y0 Y1 ω = Y1 ω := by
+  simp [observedOutcome, hD]
+
+@[simp] theorem observedOutcome_of_untreated
+    {D : Ω → Bool} {Y0 Y1 : Ω → ℝ} {ω : Ω} (hD : D ω = false) :
+    observedOutcome D Y0 Y1 ω = Y0 ω := by
+  simp [observedOutcome, hD]
+
+@[simp] theorem treatmentEffect_eq_sub (Y0 Y1 : Ω → ℝ) :
+    treatmentEffect Y0 Y1 = fun ω => Y1 ω - Y0 ω := rfl
+
+section Probability
+
+variable [MeasurableSpace Ω] [MeasurableSpace β]
+variable {μ : Measure Ω}
+
+/-- Average treatment effect: the population mean of the individual treatment effect.
+Hansen Definition 2.7 calls this the average causal effect, `ACE`. -/
+noncomputable def averageTreatmentEffect (μ : Measure Ω) (Y0 Y1 : Ω → ℝ) : ℝ :=
+  ∫ ω, treatmentEffect Y0 Y1 ω ∂μ
+
+/-- Conditional mean of a potential outcome after conditioning on observed covariates. -/
+noncomputable def potentialOutcomeMeanOn
+    (μ : Measure Ω) (Yd : Ω → ℝ) (X : Ω → β) : Ω → ℝ :=
+  condExpOn μ Yd X
+
+/-- Conditional average treatment effect after conditioning on observed covariates.
+Hansen Definition 2.8 writes this as the conditional average causal effect, `ACE(x)`. -/
+noncomputable def conditionalAverageTreatmentEffectOn
+    (μ : Measure Ω) (Y0 Y1 : Ω → ℝ) (X : Ω → β) : Ω → ℝ :=
+  condExpOn μ (treatmentEffect Y0 Y1) X
+
+/-- Difference between the conditional means of the treated and untreated potential outcomes. -/
+noncomputable def conditionalPotentialOutcomeContrastOn
+    (μ : Measure Ω) (Y0 Y1 : Ω → ℝ) (X : Ω → β) : Ω → ℝ :=
+  fun ω => potentialOutcomeMeanOn μ Y1 X ω - potentialOutcomeMeanOn μ Y0 X ω
+
+/-- A mean-independence bridge toward Hansen's conditional-independence assumption:
+conditioning on treatment and covariates gives the same potential-outcome conditional means as
+conditioning on covariates alone. CIA implies this condition under standard integrability and
+regular-conditional-probability hypotheses. -/
+def TreatmentMeanIndependentOn
+    (μ : Measure Ω) (Y0 Y1 : Ω → ℝ) (D : Ω → Bool) (X : Ω → β) : Prop :=
+  condExpOn μ Y0 (fun ω => (D ω, X ω)) =ᵐ[μ] condExpOn μ Y0 X ∧
+    condExpOn μ Y1 (fun ω => (D ω, X ω)) =ᵐ[μ] condExpOn μ Y1 X
+
+/-- The average treatment effect is the difference in the means of the two potential outcomes.
+Hansen writes this quantity as `ACE`. -/
+theorem averageTreatmentEffect_eq_integral_sub
+    {Y0 Y1 : Ω → ℝ}
+    (hY1 : Integrable Y1 μ) (hY0 : Integrable Y0 μ) :
+    averageTreatmentEffect μ Y0 Y1 = ∫ ω, Y1 ω ∂μ - ∫ ω, Y0 ω ∂μ := by
+  simp [averageTreatmentEffect, treatmentEffect, integral_sub hY1 hY0]
+
+/-- Conditional average treatment effects are the difference in conditional means of the two
+potential outcomes. Hansen writes this quantity as `ACE(x)`. -/
+theorem conditionalAverageTreatmentEffectOn_eq_sub
+    {Y0 Y1 : Ω → ℝ} {X : Ω → β}
+    (hY1 : Integrable Y1 μ) (hY0 : Integrable Y0 μ) :
+    conditionalAverageTreatmentEffectOn μ Y0 Y1 X =ᵐ[μ]
+      fun ω => potentialOutcomeMeanOn μ Y1 X ω - potentialOutcomeMeanOn μ Y0 X ω := by
+  simpa [conditionalAverageTreatmentEffectOn, potentialOutcomeMeanOn,
+      treatmentEffect, condExpOn] using
+    (MeasureTheory.condExp_sub
+      (μ := μ) (f := Y1) (g := Y0) hY1 hY0 (conditioningSpace X))
+
+/-- CATE equals the reusable contrast between conditional potential-outcome means. -/
+theorem conditionalAverageTreatmentEffectOn_eq_conditionalPotentialOutcomeContrastOn
+    {Y0 Y1 : Ω → ℝ} {X : Ω → β}
+    (hY1 : Integrable Y1 μ) (hY0 : Integrable Y0 μ) :
+    conditionalAverageTreatmentEffectOn μ Y0 Y1 X =ᵐ[μ]
+      conditionalPotentialOutcomeContrastOn μ Y0 Y1 X := by
+  simpa [conditionalPotentialOutcomeContrastOn] using
+    conditionalAverageTreatmentEffectOn_eq_sub (μ := μ) (X := X) hY1 hY0
+
+/-- The average treatment effect is the mean of the CATE. Hansen writes this as the identity
+`ACE = ∫ ACE(x) f(x) dx`; this is the potential-outcomes version of the tower property. -/
+theorem averageTreatmentEffect_eq_integral_conditionalAverageTreatmentEffectOn
+    {Y0 Y1 : Ω → ℝ} {X : Ω → β}
+    (hX : Measurable X)
+    [SigmaFinite (μ.trim (conditioningSpace_le hX))] :
+    averageTreatmentEffect μ Y0 Y1 =
+      ∫ ω, conditionalAverageTreatmentEffectOn μ Y0 Y1 X ω ∂μ := by
+  exact
+    (simple_law_iterated_expectation_rv
+      (μ := μ) (Y := treatmentEffect Y0 Y1) (X := X) hX).symm
+
+/-- The average treatment effect is also the mean of the conditional potential-outcome contrast.
+This is the a.e. Lean version of Hansen's identity `ACE = ∫ ACE(x) f(x) dx` after rewriting
+the CATE as a difference of conditional potential-outcome means. -/
+theorem averageTreatmentEffect_eq_integral_conditionalPotentialOutcomeContrastOn
+    {Y0 Y1 : Ω → ℝ} {X : Ω → β}
+    (hX : Measurable X)
+    [SigmaFinite (μ.trim (conditioningSpace_le hX))]
+    (hY1 : Integrable Y1 μ) (hY0 : Integrable Y0 μ) :
+    averageTreatmentEffect μ Y0 Y1 =
+      ∫ ω, conditionalPotentialOutcomeContrastOn μ Y0 Y1 X ω ∂μ := by
+  rw [averageTreatmentEffect_eq_integral_conditionalAverageTreatmentEffectOn (μ := μ) hX]
+  exact integral_congr_ae
+    (conditionalAverageTreatmentEffectOn_eq_conditionalPotentialOutcomeContrastOn
+      (μ := μ) (X := X) hY1 hY0)
+
+/-- If treatment is mean-independent of potential outcomes after conditioning on `X`, then adding
+the treatment indicator to the conditioning variables does not change the conditional
+potential-outcome contrast. -/
+theorem conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_of_meanIndependent
+    {Y0 Y1 : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hmean : TreatmentMeanIndependentOn μ Y0 Y1 D X) :
+    conditionalPotentialOutcomeContrastOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ]
+      conditionalPotentialOutcomeContrastOn μ Y0 Y1 X := by
+  filter_upwards [hmean.2, hmean.1] with ω hY1 hY0
+  simp [conditionalPotentialOutcomeContrastOn, potentialOutcomeMeanOn, hY1, hY0]
+
+/-- Mean-independence bridge for the variable-facing version of Hansen Theorem 2.12. Under the
+mean-independence consequence of CIA, the potential-outcome contrast after conditioning on
+`(D, X)` equals the conditional average treatment effect after conditioning on `X`. -/
+theorem conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_cate_of_meanIndependent
+    {Y0 Y1 : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hmean : TreatmentMeanIndependentOn μ Y0 Y1 D X)
+    (hY1 : Integrable Y1 μ) (hY0 : Integrable Y0 μ) :
+    conditionalPotentialOutcomeContrastOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ]
+      conditionalAverageTreatmentEffectOn μ Y0 Y1 X :=
+  (conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_of_meanIndependent
+    (μ := μ) hmean).trans <|
+      (conditionalAverageTreatmentEffectOn_eq_conditionalPotentialOutcomeContrastOn
+        (μ := μ) (X := X) hY1 hY0).symm
+
+end Probability
+
+end HansenEconometrics

--- a/inventory/ch2-inventory.md
+++ b/inventory/ch2-inventory.md
@@ -17,6 +17,7 @@ Lean files:
 - [Chapter2CondExp.lean](../HansenEconometrics/Chapter2CondExp.lean)
 - [Chapter2Variance.lean](../HansenEconometrics/Chapter2Variance.lean)
 - [Chapter2LinearProjection.lean](../HansenEconometrics/Chapter2LinearProjection.lean)
+- [Chapter2PotentialOutcomes.lean](../HansenEconometrics/Chapter2PotentialOutcomes.lean)
 - reusable helpers in [ProbabilityUtils.lean](../HansenEconometrics/ProbabilityUtils.lean)
 
 ## Status
@@ -27,6 +28,9 @@ Current Lean coverage:
 - conditional variance / total variance package
 - best predictor theorem
 - population linear projection algebra through Theorems 2.9 and 2.10
+- initial potential-outcomes API for Section 2.30:
+  observed outcomes, individual/average/conditional treatment effects, and a mean-independence bridge
+  toward Theorem 2.12
 
 Current strategy:
 - prove the strongest sigma-algebra or abstract statement first
@@ -34,8 +38,9 @@ Current strategy:
 - reuse Mathlib conditional-expectation and `L²` projection infrastructure where possible
 
 Next likely Chapter 2 targets:
+- strengthen the potential-outcomes layer from the mean-independence bridge to a full CIA theorem
+  using Mathlib conditional independence or regular conditional distributions
 - decide whether any remaining Chapter 2 results are worth formalizing before moving on
-- otherwise treat Chapter 2 as a finished foundation layer for later chapters
 
 ## Proof Architecture
 
@@ -82,6 +87,21 @@ Then prove:
   `α = μY - μX' β`
   and
   `β = var[X]⁻¹ cov(X, Y)`
+
+### Level 5: potential-outcomes package
+Define:
+- observed outcome `Y = Y(1)` on treated units and `Y = Y(0)` on untreated units
+- individual treatment effect `Y(1) - Y(0)`
+- average treatment effect `E[Y(1) - Y(0)]`
+- conditional average treatment effect `E[Y(1) - Y(0) | X]`
+
+Then prove:
+- **D2.6/D2.7** `ATE = E[Y(1)] - E[Y(0)]`
+- **D2.8** `CATE(X) = E[Y(1) | X] - E[Y(0) | X]`
+- `ATE = E[CATE(X)]` by the tower property
+- a mean-independence bridge toward **T2.12**:
+  if conditioning additionally on treatment does not change the potential-outcome conditional means,
+  then the `(D, X)` potential-outcome contrast equals the CATE
 
 ## Textbook-numbered Results
 
@@ -245,6 +265,42 @@ Links:
 Notes:
 - The slope formula is a covariance-form corollary of the earlier normal-equations theorem.
 
+### D2.6-D2.9 Potential Outcomes and Conditional Independence
+
+Links:
+- [Hansen excerpt](../textbook/ch02/ch2_excerpt.txt#L2334)
+- [Potential-outcomes definitions](../HansenEconometrics/Chapter2PotentialOutcomes.lean)
+
+| LaTeX | Lean conclusion |
+| --- | --- |
+| $Y = Y(1)$ if $D=1$, and $Y = Y(0)$ if $D=0$ | <code>observedOutcome D Y0 Y1</code> |
+| $C = Y(1) - Y(0)$ | <code>treatmentEffect Y0 Y1</code> |
+| $ACE = E[Y(1)-Y(0)]$ | <code>averageTreatmentEffect μ Y0 Y1</code> |
+| $ACE(X) = E[Y(1)-Y(0) \mid X]$ | <code>conditionalAverageTreatmentEffectOn μ Y0 Y1 X</code> |
+| CIA mean-independence consequence | <code>TreatmentMeanIndependentOn μ Y0 Y1 D X</code> |
+
+Notes:
+- Hansen calls the population quantity the average causal effect, `ACE`. The Lean API uses the more
+  common causal-inference name `averageTreatmentEffect`.
+- The current Lean layer is variable-facing and a.e.-based. It does not yet formalize the pointwise
+  density notation `ACE(x)` or the full CIA-to-mean-independence implication.
+
+### T2.12 Conditional Average Causal Effects
+
+Links:
+- [Hansen excerpt](../textbook/ch02/ch2_excerpt.txt#L2521)
+- [Mean-independence bridge](../HansenEconometrics/Chapter2PotentialOutcomes.lean)
+
+| LaTeX | Lean conclusion |
+| --- | --- |
+| $ACE = \int ACE(x) f(x)\,dx$ | <code>averageTreatmentEffect μ Y0 Y1 = ∫ ω, conditionalAverageTreatmentEffectOn μ Y0 Y1 X ω ∂μ</code> |
+| Under the mean-independence consequence of CIA, the treatment-and-covariate potential-outcome contrast equals CATE | <code>conditionalPotentialOutcomeContrastOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ] conditionalAverageTreatmentEffectOn μ Y0 Y1 X</code> |
+
+Notes:
+- This is a first formal bridge toward Theorem 2.12, not the final theorem as written in Hansen.
+- The final pointwise theorem should probably use Mathlib's `CondIndepFun`/`condDistrib` layer and
+  explicit standard-Borel, integrability, and overlap assumptions.
+
 ## Lean-only Bridge Results
 
 These theorems are not direct textbook labels, but they are the key translation lemmas between
@@ -274,3 +330,10 @@ Hansen's notation and the Lean formalization.
 - [`covVec_linearProjectionModel`](../HansenEconometrics/Chapter2LinearProjection.lean#L149):
   $\operatorname{cov}(X, \alpha + X' \beta + e) = \operatorname{covMat}(X)\beta +
   \operatorname{cov}(X, e)$.
+- [`conditionalAverageTreatmentEffectOn_eq_conditionalPotentialOutcomeContrastOn`](../HansenEconometrics/Chapter2PotentialOutcomes.lean):
+  $E[Y(1)-Y(0) \mid X] = E[Y(1) \mid X] - E[Y(0) \mid X]$.
+- [`averageTreatmentEffect_eq_integral_conditionalPotentialOutcomeContrastOn`](../HansenEconometrics/Chapter2PotentialOutcomes.lean):
+  the a.e. Lean version of Hansen's identity `ACE = ∫ ACE(x) f(x) dx` after rewriting CATE as a
+  difference of conditional potential-outcome means.
+- [`conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_cate_of_meanIndependent`](../HansenEconometrics/Chapter2PotentialOutcomes.lean):
+  mean-independence bridge from conditioning on `(D, X)` to the CATE.


### PR DESCRIPTION
Adds Hansen Theorem 2.10 on top of the variable-facing probability helper layer. The branch now targets variable-module-and-style-guide, moves reusable meanVec/covVec/covMat helpers into ProbabilityUtils, and proves the intercept and slope covariance formulas in Chapter2LinearProjection. Validation: lake build HansenEconometrics.ProbabilityUtils; lake build HansenEconometrics.Chapter2LinearProjection; lake build.