### PR TITLE
Consolidate shared utility lemmas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,9 @@ Examples:
   wrappers and later proofs.
 - Chapter-facing probability theorems still belong in the chapter files when they are part of the
   chapter exposition rather than generic helper infrastructure.
-- Chapter 2.10 matrix/covariance bridges belong next to the linear-projection development rather than
-  in a new one-off file.
+- Reusable finite-dimensional mean/covariance helpers belong in
+  [HansenEconometrics/ProbabilityUtils.lean](./HansenEconometrics/ProbabilityUtils.lean), while
+  Chapter 2.10 theorem wrappers stay next to the linear-projection development.
 
 ## Crosswalk policy
 

--- a/HansenEconometrics/Chapter2LinearProjection.lean
+++ b/HansenEconometrics/Chapter2LinearProjection.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import HansenEconometrics.Basic
 import HansenEconometrics.LinearAlgebraUtils
+import HansenEconometrics.ProbabilityUtils
 
 open scoped Matrix
 
@@ -142,89 +143,19 @@ variable {Ω : Type*}
 variable {mΩ : MeasurableSpace Ω}
 variable {μ : Measure Ω}
 
-/-- Population mean of a finite-dimensional random vector. -/
-noncomputable def meanVec (μ : Measure Ω) (X : Ω → k → ℝ) : k → ℝ :=
-  ∫ ω, X ω ∂μ
-
-/-- Population covariance vector between a regressor vector `X` and a scalar outcome `Y`. -/
-noncomputable def covVec (μ : Measure Ω) (X : Ω → k → ℝ) (Y : Ω → ℝ) : k → ℝ :=
-  fun i => cov[fun ω => X ω i, Y; μ]
-
-/-- Population covariance matrix of a finite-dimensional regressor vector `X`. -/
-noncomputable def covMat (μ : Measure Ω) (X : Ω → k → ℝ) : Matrix k k ℝ :=
-  fun i j => cov[fun ω => X ω i, fun ω => X ω j; μ]
-
-/-- Integrating a linear form equals applying that linear form to the vector mean. -/
-theorem integral_dotProduct_eq_meanVec_dotProduct
-    (X : Ω → k → ℝ) (b : k → ℝ)
-    (hX : ∀ i, Integrable (fun ω => X ω i) μ) :
-    ∫ ω, dotProduct (X ω) b ∂μ = meanVec μ X ⬝ᵥ b := by
-  simp_rw [dotProduct]
-  rw [integral_finset_sum]
-  · simp_rw [integral_mul_const]
-    refine Finset.sum_congr rfl ?_
-    intro i hi
-    rw [show (∫ ω, X ω i ∂μ) = (meanVec μ X) i by
-      simpa [meanVec] using (MeasureTheory.eval_integral (μ := μ) (f := X) (hf := hX) i).symm]
-  · intro i hi
-    exact (hX i).mul_const (b i)
-
-/-- The covariance vector with a linear form equals the covariance matrix times the coefficient
-vector. -/
-theorem covVec_dotProduct_eq_covMat_mulVec
-    [IsProbabilityMeasure μ]
-    (X : Ω → k → ℝ) (b : k → ℝ)
-    (hX : ∀ i, MemLp (fun ω => X ω i) 2 μ) :
-    covVec μ X (fun ω => dotProduct (X ω) b) = covMat μ X *ᵥ b := by
-  ext i
-  change cov[fun ω => X ω i, fun ω => ∑ j, X ω j * b j; μ] =
-    ∑ j, cov[fun ω => X ω i, fun ω => X ω j; μ] * b j
-  rw [ProbabilityTheory.covariance_fun_sum_right
-      (X := fun j ω => X ω j * b j) (Y := fun ω => X ω i)]
-  · simp_rw [ProbabilityTheory.covariance_mul_const_right]
-  · intro j
-    exact (hX j).mul_const (b j)
-  · exact hX i
-
+omit [DecidableEq k] in
 /-- Covariances in the linear projection model decompose into the fitted part and the residual
-part. -/
+part. This is the Chapter 2-facing wrapper around the reusable affine-model covariance helper. -/
 theorem covVec_linearProjectionModel
     [IsProbabilityMeasure μ]
     (X : Ω → k → ℝ) (e : Ω → ℝ) (α : ℝ) (β : k → ℝ)
     (hX : ∀ i, MemLp (fun ω => X ω i) 2 μ)
     (he : MemLp e 2 μ) :
     covVec μ X (fun ω => α + dotProduct (X ω) β + e ω) =
-      covMat μ X *ᵥ β + covVec μ X e := by
-  have hlin : MemLp (fun ω => dotProduct (X ω) β) 2 μ := by
-    classical
-    convert (memLp_finset_sum' (s := Finset.univ) (f := fun j ω => X ω j * β j)
-      (fun j _ => (hX j).mul_const (β j))) using 1
-    ext ω
-    simp [dotProduct]
-  ext i
-  change cov[fun ω => X ω i, fun ω => α + dotProduct (X ω) β + e ω; μ] =
-    (covMat μ X *ᵥ β) i + cov[fun ω => X ω i, e; μ]
-  calc
-    cov[fun ω => X ω i, fun ω => α + dotProduct (X ω) β + e ω; μ]
-        = cov[fun ω => X ω i, fun ω => α + dotProduct (X ω) β; μ] +
-            cov[fun ω => X ω i, e; μ] := by
-              change cov[fun ω => X ω i, (fun ω => α + dotProduct (X ω) β) + e; μ] = _
-              simpa using
-                (ProbabilityTheory.covariance_add_right (X := fun ω => X ω i)
-                  (Y := fun ω => α + dotProduct (X ω) β) (Z := e)
-                  (hX i) ((memLp_const α).add hlin) he)
-    _ = cov[fun ω => X ω i, fun ω => dotProduct (X ω) β; μ] +
-          cov[fun ω => X ω i, e; μ] := by
-            simpa using
-              (ProbabilityTheory.covariance_const_add_right (X := fun ω => X ω i)
-                (Y := fun ω => dotProduct (X ω) β) (μ := μ)
-                (hlin.integrable (by norm_num)) α)
-    _ = (covMat μ X *ᵥ β) i + cov[fun ω => X ω i, e; μ] := by
-          rw [show cov[fun ω => X ω i, fun ω => dotProduct (X ω) β; μ] =
-              (covMat μ X *ᵥ β) i by
-                simpa [covVec] using
-                  congrFun (covVec_dotProduct_eq_covMat_mulVec (μ := μ) X β hX) i]
+      covMat μ X *ᵥ β + covVec μ X e :=
+  covVec_affineModel (μ := μ) X e α β hX he
 
+omit [DecidableEq k] in
 /-- Hansen Theorem 2.10 intercept formula in the linear projection model. -/
 theorem linearProjectionIntercept_eq_mean_sub_dotProduct
     [IsProbabilityMeasure μ]

--- a/HansenEconometrics/Chapter3Projections.lean
+++ b/HansenEconometrics/Chapter3Projections.lean
@@ -159,38 +159,6 @@ theorem hatMatrix_isHermitian
     (hatMatrix X).IsHermitian :=
   (Matrix.conjTranspose_eq_transpose_of_trivial _).trans (hatMatrix_transpose X)
 
-/-- For a real symmetric idempotent matrix, rank equals the natural-number value of the trace.
-Eigenvalues of such a matrix are 0 or 1, so
-rank = #{nonzero eigenvalues} = ∑ eigenvalues = trace. -/
-theorem rank_eq_natCast_trace_of_isHermitian_idempotent
-    {A : Matrix n n ℝ}
-    (hH : A.IsHermitian)
-    (hI : IsIdempotentElem A) :
-    (A.rank : ℝ) = A.trace := by
-  classical
-  -- Eigenvalues of a Hermitian idempotent are 0 or 1
-  have heig : ∀ i : n, hH.eigenvalues i = 0 ∨ hH.eigenvalues i = 1 := by
-    intro i
-    have hmem := hI.spectrum_subset ℝ (hH.eigenvalues_mem_spectrum_real i)
-    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
-    exact hmem
-  rw [hH.rank_eq_card_non_zero_eigs, hH.trace_eq_sum_eigenvalues]
-  -- ↑(card {i // eigenvalues i ≠ 0}) = ∑ i, (eigenvalues i : ℝ)
-  simp only [RCLike.ofReal_real_eq_id, id]
-  -- Each nonzero eigenvalue is 1
-  have heig1 : ∀ i : n, hH.eigenvalues i ≠ 0 → hH.eigenvalues i = 1 :=
-    fun i hi => (heig i).resolve_left hi
-  symm
-  calc ∑ i : n, hH.eigenvalues i
-      = ∑ i : n, if hH.eigenvalues i ≠ 0 then (1 : ℝ) else 0 :=
-          Finset.sum_congr rfl (fun i _ => by rcases heig i with h | h <;> simp [h])
-    _ = ↑(Finset.univ.filter (fun i : n => hH.eigenvalues i ≠ 0)).card :=
-          Finset.sum_boole _ _
-    _ = ↑(Fintype.card {i : n // hH.eigenvalues i ≠ 0}) := by
-          congr 1
-          exact (Fintype.card_of_subtype _ (fun x => by
-            simp only [Finset.mem_filter, Finset.mem_univ, true_and])).symm
-
 /-- The rank of the annihilator matrix plus the number of regressors equals
 the number of observations. Equivalent to rank(M) = n − k. -/
 theorem rank_annihilatorMatrix_add

--- a/HansenEconometrics/Chapter4LeastSquaresRegression.lean
+++ b/HansenEconometrics/Chapter4LeastSquaresRegression.lean
@@ -127,7 +127,7 @@ theorem gaussMarkov_variance_gap_posSemidef
     have h2' : (Xᵀ * X)⁻¹ - (Xᵀ * X)⁻¹ * (Xᵀ * (X * (Xᵀ * X)⁻¹)) = 0 := by
       have hcancel : Xᵀ * (X * (Xᵀ * X)⁻¹) = (1 : Matrix k k ℝ) := by
         rw [← Matrix.mul_assoc]
-        simpa using (mul_invOf_self (Xᵀ * X))
+        simpa only [invOf_eq_nonsing_inv] using (mul_invOf_self (Xᵀ * X))
       rw [hcancel]
       simp
     have h1' : Aᵀ * (X * (Xᵀ * X)⁻¹) = (Xᵀ * X)⁻¹ := by
@@ -834,16 +834,18 @@ theorem generalizedGaussMarkov_variance_gap_posSemidef
   have hΩsym : Ωᵀ = Ω := by
     simpa [Matrix.IsHermitian] using hΩ.1
   have hsymW : (Xᵀ * ⅟Ω * X)ᵀ = Xᵀ * ⅟Ω * X := by
-    rw [Matrix.transpose_mul, Matrix.transpose_mul, Matrix.transpose_transpose, Matrix.transpose_invOf]
-    simpa [hΩsym, Matrix.mul_assoc]
+    rw [Matrix.transpose_mul, Matrix.transpose_mul, Matrix.transpose_transpose,
+      Matrix.transpose_invOf]
+    simp [hΩsym, Matrix.mul_assoc]
   have hMtranspose : Mᵀ = M := by
     dsimp [M]
     rw [Matrix.transpose_invOf]
     simpa [hsymW] using congrArg Inv.inv hsymW
   have hCtranspose : Cᵀ = Ω * A - X * M := by
     dsimp [C]
-    rw [Matrix.transpose_sub, Matrix.transpose_mul, Matrix.transpose_mul, Matrix.transpose_transpose]
-    simp [hMtranspose, hΩsym, Matrix.mul_assoc]
+    rw [Matrix.transpose_sub, Matrix.transpose_mul, Matrix.transpose_mul,
+      Matrix.transpose_transpose]
+    simp [hMtranspose, hΩsym]
   have hgap : C * ⅟Ω * Cᵀ = Aᵀ * Ω * A - M := by
     calc
       C * ⅟Ω * Cᵀ = ((Aᵀ * Ω - M * Xᵀ) * ⅟Ω) * (Ω * A - X * M) := by

--- a/HansenEconometrics/Chapter5NormalRegression.lean
+++ b/HansenEconometrics/Chapter5NormalRegression.lean
@@ -26,8 +26,8 @@ noncomputable def olsResidualVarianceEstimator
 structure NormalRegressionModel (X : Matrix n k ℝ) (β : k → ℝ) (σ2 : ℝ) where
   sigma2_nonneg : 0 ≤ σ2
 
-/-- Under the linear model, the residual variance estimator is the residual quadratic form divided by
-`n-k`, expressed directly in terms of the model error. -/
+/-- Under the linear model, the residual variance estimator is the residual quadratic form
+ divided by `n-k`, expressed directly in terms of the model error. -/
 theorem olsResidualVarianceEstimator_linear_model
     (X : Matrix n k ℝ) (β : k → ℝ) (e : n → ℝ) [Invertible (Xᵀ * X)] :
     olsResidualVarianceEstimator X (X *ᵥ β + e)
@@ -51,8 +51,8 @@ theorem residual_quadratic_form_of_linear_model
     (annihilatorMatrix_idempotent X)
     e
 
-/-- Under the linear model, the residual variance estimator is the annihilator quadratic form divided
-by `n-k`. This is the deterministic identity underlying the chi-square step. -/
+/-- Under the linear model, the residual variance estimator is the annihilator quadratic
+form divided by `n-k`. This is the deterministic identity underlying the chi-square step. -/
 theorem olsResidualVarianceEstimator_linear_model_quadratic_form
     (X : Matrix n k ℝ) (β : k → ℝ) (e : n → ℝ) [Invertible (Xᵀ * X)] :
     olsResidualVarianceEstimator X (X *ᵥ β + e)
@@ -89,8 +89,8 @@ theorem olsBeta_hasGaussianLaw_of_error
   rw [olsBeta_linear_decomposition]
   simp [L]
 
-/-- If the error vector has a Gaussian law, then the OLS residual vector is Gaussian as a linear image
-of the error vector. -/
+/-- If the error vector has a Gaussian law, then the OLS residual vector is Gaussian
+as a linear image of the error vector. -/
 theorem residual_hasGaussianLaw_of_error
     {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     (X : Matrix n k ℝ) (β : k → ℝ) (e : Ω → n → ℝ)

--- a/HansenEconometrics/ChiSquared.lean
+++ b/HansenEconometrics/ChiSquared.lean
@@ -9,6 +9,8 @@ import Mathlib.Analysis.LConvolution
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import HansenEconometrics.LinearAlgebraUtils
+import HansenEconometrics.ProbabilityUtils
 
 open MeasureTheory ProbabilityTheory
 
@@ -544,7 +546,7 @@ private lemma gammaPDF_lconvolution_eq {a b r : ℝ} (hr : 0 < r) (ha : 0 < a) (
             (Real.exp (-(r * y)) * Real.exp (-(r * (-y + x)))) := by ring
         _ = r ^ a / Real.Gamma a * (r ^ b / Real.Gamma b) *
             (y ^ (a - 1) * (x - y) ^ (b - 1)) * Real.exp (-(r * x)) := by
-              rw [← Real.exp_add]; congr 1; ring
+              rw [← Real.exp_add]; congr 1; ring_nf
         _ = r ^ a / Real.Gamma a * (r ^ b / Real.Gamma b) * Real.exp (-(r * x)) *
             (y ^ (a - 1) * (x - y) ^ (b - 1)) := by ring
     -- Step 4: conclude via constant pull-out.
@@ -637,13 +639,13 @@ theorem hasLaw_add_chiSquared
   rw [chiSquared_eq (a + b)]
   exact hsum
 
-theorem hasLaw_sum_sq_chiSquared
+theorem hasLaw_sumSquaresRV_chiSquared
     {k : ℕ} (hk : 0 < k)
     {Ω : Type*} [MeasureSpace Ω]
     {W : Fin k → Ω → ℝ}
     (hLaw : ∀ i, HasLaw (W i) (gaussianReal 0 1))
     (hIndep : ProbabilityTheory.iIndepFun W) :
-    HasLaw (fun ω => ∑ i, (W i ω)^2) (chiSquared k) := by
+    HasLaw (sumSquaresRV W) (chiSquared k) := by
   -- Reduce `k` to `n + 1` so we can induct on `n`.
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk.ne'
   clear hk
@@ -653,6 +655,7 @@ theorem hasLaw_sum_sq_chiSquared
     have hsum_eq : (fun ω => ∑ i : Fin 1, (W i ω)^2) = (fun ω => (W 0 ω)^2) := by
       funext ω
       simp
+    change HasLaw (fun ω => ∑ i : Fin 1, (W i ω)^2) (chiSquared 1)
     rw [hsum_eq]
     exact hasLaw_sq_chiSquared_one (hLaw 0)
   | succ n ih =>
@@ -721,139 +724,25 @@ theorem hasLaw_sum_sq_chiSquared
         (fun ω => (∑ i : Fin (n + 1), (V i ω)^2) + (W (Fin.last (n + 1)) ω)^2) := by
       funext ω
       simp [Fin.sum_univ_castSucc, V]
+    change HasLaw (fun ω => ∑ i : Fin (n + 2), (W i ω)^2) (chiSquared (n + 2))
     rw [hgoal_eq]
     exact hAdd
+
+/-- Sum of squares of independent standard normal random variables has a chi-squared law. -/
+theorem hasLaw_sum_sq_chiSquared
+    {k : ℕ} (hk : 0 < k)
+    {Ω : Type*} [MeasureSpace Ω]
+    {W : Fin k → Ω → ℝ}
+    (hLaw : ∀ i, HasLaw (W i) (gaussianReal 0 1))
+    (hIndep : ProbabilityTheory.iIndepFun W) :
+    HasLaw (fun ω => ∑ i, (W i ω)^2) (chiSquared k) := by
+  simpa [sumSquaresRV] using hasLaw_sumSquaresRV_chiSquared hk hLaw hIndep
 
 /-! ### Chi-squared distribution of quadratic forms with symmetric idempotent matrices -/
 
 section QuadraticFormChiSquared
 
 open Matrix
-
-/-- Spectral expansion of the quadratic form `z ⬝ᵥ M *ᵥ z` in the eigenbasis of a
-Hermitian real matrix: it equals the sum of eigenvalues times squared basis coordinates. -/
-lemma quadForm_eq_sum_eigenvalues
-    {n : ℕ} {M : Matrix (Fin n) (Fin n) ℝ} (hH : M.IsHermitian)
-    (z : EuclideanSpace ℝ (Fin n)) :
-    (z : Fin n → ℝ) ⬝ᵥ (M *ᵥ (z : Fin n → ℝ))
-      = ∑ i, hH.eigenvalues i * (hH.eigenvectorBasis.repr z i) ^ 2 := by
-  set b := hH.eigenvectorBasis with hb_def
-  -- Write (z : Fin n → ℝ) as a sum in the eigenbasis.
-  have hz_coord : (z : Fin n → ℝ) = ∑ i, b.repr z i • ((b i : Fin n → ℝ)) := by
-    have hsum : z = ∑ i, b.repr z i • b i := (b.sum_repr z).symm
-    have : ((z : EuclideanSpace ℝ (Fin n)) : Fin n → ℝ)
-        = (((∑ i, b.repr z i • b i) : EuclideanSpace ℝ (Fin n)) : Fin n → ℝ) :=
-      congrArg _ hsum
-    rw [this, WithLp.ofLp_sum]
-    rfl
-  -- Apply M to that sum; linearity + eigenvector identity.
-  have hMz_coord : M *ᵥ (z : Fin n → ℝ)
-      = ∑ i, (b.repr z i * hH.eigenvalues i) • ((b i : Fin n → ℝ)) := by
-    rw [hz_coord, Matrix.mulVec_sum]
-    refine Finset.sum_congr rfl (fun i _ => ?_)
-    rw [Matrix.mulVec_smul, hH.mulVec_eigenvectorBasis, smul_smul]
-  -- Orthonormality of the eigenbasis as `Fin n → ℝ` vectors.  For real scalars the inner
-  -- product coincides with the (flipped) dot product: ⟪x, y⟫_ℝ = y ⬝ᵥ x.
-  have hinner_eq_dot : ∀ x y : EuclideanSpace ℝ (Fin n),
-      @inner ℝ (EuclideanSpace ℝ (Fin n)) _ x y = ((y : Fin n → ℝ)) ⬝ᵥ ((x : Fin n → ℝ)) :=
-    fun _ _ => rfl
-  have horth : ∀ i j : Fin n,
-      ((b i : Fin n → ℝ)) ⬝ᵥ ((b j : Fin n → ℝ)) = if i = j then (1 : ℝ) else 0 := by
-    intro i j
-    rw [dotProduct_comm, ← hinner_eq_dot]
-    have := (orthonormal_iff_ite.mp b.orthonormal) i j
-    simpa using this
-  -- Expand the dot product step by step.
-  rw [hMz_coord, hz_coord, sum_dotProduct]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [smul_dotProduct, dotProduct_sum, smul_eq_mul]
-  have step : ∀ j, (b i : Fin n → ℝ) ⬝ᵥ ((b.repr z j * hH.eigenvalues j) • (b j : Fin n → ℝ))
-      = (b.repr z j * hH.eigenvalues j) * (if i = j then (1 : ℝ) else 0) := by
-    intro j; rw [dotProduct_smul, horth, smul_eq_mul]
-  simp_rw [step]
-  rw [Finset.sum_congr rfl (fun j _ => show
-    (b.repr z j * hH.eigenvalues j) * (if i = j then (1 : ℝ) else 0)
-      = if i = j then b.repr z i * hH.eigenvalues i else 0 by
-    split_ifs with hij
-    · rw [hij]; ring
-    · ring)]
-  rw [Finset.sum_ite_eq Finset.univ i]
-  simp
-  ring
-
-/-- For a Hermitian idempotent real matrix, the number of indices whose eigenvalue is `1`
-equals the rank of the matrix. -/
-lemma card_eigenvalue_one_eq_rank_of_isHermitian_idempotent
-    {n : ℕ} {M : Matrix (Fin n) (Fin n) ℝ}
-    (hH : M.IsHermitian) (hI : IsIdempotentElem M) :
-    (Finset.univ.filter (fun i : Fin n => hH.eigenvalues i = 1)).card = M.rank := by
-  -- Eigenvalues of a Hermitian idempotent real matrix are 0 or 1.
-  have heig : ∀ i : Fin n, hH.eigenvalues i = 0 ∨ hH.eigenvalues i = 1 := fun i => by
-    have hmem := hI.spectrum_subset ℝ (hH.eigenvalues_mem_spectrum_real i)
-    simpa using hmem
-  -- So the "= 1" predicate coincides with the "≠ 0" predicate.
-  have hfilter_eq : Finset.univ.filter (fun i : Fin n => hH.eigenvalues i = 1)
-      = Finset.univ.filter (fun i : Fin n => hH.eigenvalues i ≠ 0) := by
-    ext i
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-    constructor
-    · intro h; rw [h]; norm_num
-    · exact (heig i).resolve_left
-  rw [hfilter_eq, hH.rank_eq_card_non_zero_eigs, Fintype.card_subtype]
-
-/-- The coordinates of a standard Gaussian vector in an orthonormal basis are i.i.d. standard
-normal. -/
-lemma hasLaw_coords_of_stdGaussian
-    {n : ℕ} {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (volume : Measure Ω)]
-    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
-    [FiniteDimensional ℝ E] [MeasurableSpace E] [BorelSpace E]
-    (b : OrthonormalBasis (Fin n) ℝ E)
-    {Z : Ω → E} (hZ : HasLaw Z (stdGaussian E)) :
-    (∀ i, HasLaw (fun ω => b.repr (Z ω) i) (gaussianReal 0 1)) ∧
-      iIndepFun (fun i ω => b.repr (Z ω) i) := by
-  -- Package `b.repr` as a HasLaw via Mathlib's `stdGaussian_map`.
-  have hRepr : HasLaw (fun x : E => (b.repr x : EuclideanSpace ℝ (Fin n)))
-      (stdGaussian (EuclideanSpace ℝ (Fin n))) (stdGaussian E) :=
-    ⟨b.repr.continuous.aemeasurable, stdGaussian_map b.repr⟩
-  have hbZ : HasLaw (fun ω => b.repr (Z ω)) (stdGaussian (EuclideanSpace ℝ (Fin n))) :=
-    hRepr.comp hZ
-  -- Bridge from `stdGaussian` on `EuclideanSpace` to `Measure.pi (fun _ => gaussianReal 0 1)`
-  -- via the `ofLp` coercion (inverse of `toLp 2`).
-  have hm_of : Measurable (WithLp.ofLp : EuclideanSpace ℝ (Fin n) → (Fin n → ℝ)) := by fun_prop
-  have hm_to : Measurable (WithLp.toLp 2 : (Fin n → ℝ) → EuclideanSpace ℝ (Fin n)) := by fun_prop
-  have hOfLp_map : (stdGaussian (EuclideanSpace ℝ (Fin n))).map
-        (WithLp.ofLp : EuclideanSpace ℝ (Fin n) → (Fin n → ℝ))
-      = Measure.pi (fun _ : Fin n => gaussianReal 0 1) := by
-    rw [← map_pi_eq_stdGaussian (ι := Fin n), Measure.map_map hm_of hm_to]
-    simp [Function.comp_def]
-  have hOfLp : HasLaw (fun x : EuclideanSpace ℝ (Fin n) => (x : Fin n → ℝ))
-      (Measure.pi (fun _ : Fin n => gaussianReal 0 1))
-      (stdGaussian (EuclideanSpace ℝ (Fin n))) :=
-    ⟨hm_of.aemeasurable, hOfLp_map⟩
-  have hbZ_coord : HasLaw (fun ω => ((b.repr (Z ω)) : Fin n → ℝ))
-      (Measure.pi (fun _ : Fin n => gaussianReal 0 1)) :=
-    hOfLp.comp hbZ
-  -- Per-coordinate laws via projection through the product measure.
-  have hLaw : ∀ i : Fin n, HasLaw (fun ω => b.repr (Z ω) i) (gaussianReal 0 1) := by
-    intro i
-    refine ⟨hbZ_coord.aemeasurable.eval i, ?_⟩
-    have h1 : (volume : Measure Ω).map (fun ω => b.repr (Z ω) i)
-        = ((volume : Measure Ω).map (fun ω => ((b.repr (Z ω)) : Fin n → ℝ))).map
-            (fun f : Fin n → ℝ => f i) := by
-      rw [AEMeasurable.map_map_of_aemeasurable (measurable_pi_apply i).aemeasurable
-        hbZ_coord.aemeasurable]
-      rfl
-    rw [h1, hbZ_coord.map_eq]
-    exact (measurePreserving_eval (fun _ : Fin n => gaussianReal 0 1) i).map_eq
-  -- Independence via the product-measure characterization.
-  refine ⟨hLaw, ?_⟩
-  rw [iIndepFun_iff_map_fun_eq_pi_map (fun i => (hLaw i).aemeasurable)]
-  rw [show (fun (ω : Ω) (i : Fin n) => b.repr (Z ω) i)
-      = (fun ω => ((b.repr (Z ω)) : Fin n → ℝ)) from rfl]
-  rw [hbZ_coord.map_eq]
-  congr 1
-  funext i
-  exact ((hLaw i).map_eq).symm
 
 /-- **Quadratic-form chi-squared theorem.** If `Z` is a standard Gaussian vector in
 `EuclideanSpace ℝ (Fin n)` and `M` is a symmetric idempotent real `n × n` matrix of rank `r > 0`,
@@ -913,7 +802,7 @@ theorem hasLaw_quadForm_symmIdem_chiSquared
       = (fun ω => ∑ i : Fin M.rank, (W i ω) ^ 2) := by
     funext ω; rw [hQF' ω, hSumReindex ω]
   rw [hTarget]
-  exact hasLaw_sum_sq_chiSquared hr hLawW hIndepW
+  simpa [sumSquaresRV] using hasLaw_sumSquaresRV_chiSquared hr hLawW hIndepW
 
 end QuadraticFormChiSquared
 

--- a/HansenEconometrics/LinearAlgebraUtils.lean
+++ b/HansenEconometrics/LinearAlgebraUtils.lean
@@ -6,24 +6,23 @@ namespace HansenEconometrics
 
 open Matrix
 
-variable {m n : Type*}
-variable [Fintype m] [Fintype n]
-
 /-- Left-multiplication by a row vector is right-multiplication by the transpose. -/
-lemma vecMul_eq_mulVec_transpose (M : Matrix m n ℝ) (x : m → ℝ) :
+lemma vecMul_eq_mulVec_transpose {m n : Type*} [Fintype m]
+    (M : Matrix m n ℝ) (x : m → ℝ) :
     Matrix.vecMul x M = Mᵀ *ᵥ x := by
   simpa using (Matrix.vecMul_transpose Mᵀ x)
 
-/-- For a symmetric matrix, left-multiplication as a row vector agrees with right-multiplication as a
-column vector. -/
-lemma vecMul_eq_mulVec_of_transpose_eq_self
+/-- For a symmetric matrix, left-multiplication as a row vector agrees with right-multiplication
+as a column vector. -/
+lemma vecMul_eq_mulVec_of_transpose_eq_self {n : Type*} [Fintype n]
     (M : Matrix n n ℝ) (hM : Mᵀ = M) (x : n → ℝ) :
     Matrix.vecMul x M = M *ᵥ x := by
   simpa [hM] using vecMul_eq_mulVec_transpose M x
 
-/-- For a symmetric idempotent matrix, the associated quadratic form equals the squared norm of the
-projected vector. This is the linear-algebra identity behind projection-based chi-square arguments. -/
-lemma quadratic_form_eq_dotProduct_of_symm_idempotent
+/-- For a symmetric idempotent matrix, the associated quadratic form equals the squared norm of
+the projected vector. This is the linear-algebra identity behind projection-based chi-square
+arguments. -/
+lemma quadratic_form_eq_dotProduct_of_symm_idempotent {n : Type*} [Fintype n]
     (M : Matrix n n ℝ) (hMt : Mᵀ = M) (hMid : M * M = M) (x : n → ℝ) :
     x ⬝ᵥ M *ᵥ x = dotProduct (M *ᵥ x) (M *ᵥ x) := by
   have hvec : Matrix.vecMul x M = M *ᵥ x :=
@@ -31,5 +30,108 @@ lemma quadratic_form_eq_dotProduct_of_symm_idempotent
   have h := Matrix.dotProduct_mulVec x M (M *ᵥ x)
   rw [hvec, Matrix.mulVec_mulVec, hMid] at h
   exact h
+
+/-- For a real symmetric idempotent matrix, rank equals the natural-number value of the trace.
+Eigenvalues of such a matrix are 0 or 1, so
+rank = #{nonzero eigenvalues} = ∑ eigenvalues = trace. -/
+theorem rank_eq_natCast_trace_of_isHermitian_idempotent {n : Type*} [Fintype n]
+    {A : Matrix n n ℝ}
+    (hH : A.IsHermitian)
+    (hI : IsIdempotentElem A) :
+    (A.rank : ℝ) = A.trace := by
+  classical
+  -- Eigenvalues of a Hermitian idempotent are 0 or 1.
+  have heig : ∀ i : n, hH.eigenvalues i = 0 ∨ hH.eigenvalues i = 1 := by
+    intro i
+    have hmem := hI.spectrum_subset ℝ (hH.eigenvalues_mem_spectrum_real i)
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
+    exact hmem
+  rw [hH.rank_eq_card_non_zero_eigs, hH.trace_eq_sum_eigenvalues]
+  -- ↑(card {i // eigenvalues i ≠ 0}) = ∑ i, (eigenvalues i : ℝ)
+  simp only [RCLike.ofReal_real_eq_id, id]
+  -- Each nonzero eigenvalue is 1.
+  have heig1 : ∀ i : n, hH.eigenvalues i ≠ 0 → hH.eigenvalues i = 1 :=
+    fun i hi => (heig i).resolve_left hi
+  symm
+  calc ∑ i : n, hH.eigenvalues i
+      = ∑ i : n, if hH.eigenvalues i ≠ 0 then (1 : ℝ) else 0 :=
+          Finset.sum_congr rfl (fun i _ => by rcases heig i with h | h <;> simp [h])
+    _ = ↑(Finset.univ.filter (fun i : n => hH.eigenvalues i ≠ 0)).card :=
+          Finset.sum_boole _ _
+    _ = ↑(Fintype.card {i : n // hH.eigenvalues i ≠ 0}) := by
+          congr 1
+          exact (Fintype.card_of_subtype _ (fun x => by
+            simp only [Finset.mem_filter, Finset.mem_univ, true_and])).symm
+
+/-- Spectral expansion of the quadratic form `z ⬝ᵥ M *ᵥ z` in the eigenbasis of a
+Hermitian real matrix: it equals the sum of eigenvalues times squared basis coordinates. -/
+lemma quadForm_eq_sum_eigenvalues
+    {n : ℕ} {M : Matrix (Fin n) (Fin n) ℝ} (hH : M.IsHermitian)
+    (z : EuclideanSpace ℝ (Fin n)) :
+    (z : Fin n → ℝ) ⬝ᵥ (M *ᵥ (z : Fin n → ℝ))
+      = ∑ i, hH.eigenvalues i * (hH.eigenvectorBasis.repr z i) ^ 2 := by
+  set b := hH.eigenvectorBasis with hb_def
+  -- Write (z : Fin n → ℝ) as a sum in the eigenbasis.
+  have hz_coord : (z : Fin n → ℝ) = ∑ i, b.repr z i • ((b i : Fin n → ℝ)) := by
+    have hsum : z = ∑ i, b.repr z i • b i := (b.sum_repr z).symm
+    have : ((z : EuclideanSpace ℝ (Fin n)) : Fin n → ℝ)
+        = (((∑ i, b.repr z i • b i) : EuclideanSpace ℝ (Fin n)) : Fin n → ℝ) :=
+      congrArg _ hsum
+    rw [this, WithLp.ofLp_sum]
+    rfl
+  -- Apply M to that sum; linearity + eigenvector identity.
+  have hMz_coord : M *ᵥ (z : Fin n → ℝ)
+      = ∑ i, (b.repr z i * hH.eigenvalues i) • ((b i : Fin n → ℝ)) := by
+    rw [hz_coord, Matrix.mulVec_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Matrix.mulVec_smul, hH.mulVec_eigenvectorBasis, smul_smul]
+  -- Orthonormality of the eigenbasis as `Fin n → ℝ` vectors. For real scalars the inner
+  -- product coincides with the flipped dot product: `⟪x, y⟫_ℝ = y ⬝ᵥ x`.
+  have hinner_eq_dot : ∀ x y : EuclideanSpace ℝ (Fin n),
+      @inner ℝ (EuclideanSpace ℝ (Fin n)) _ x y = ((y : Fin n → ℝ)) ⬝ᵥ ((x : Fin n → ℝ)) :=
+    fun _ _ => rfl
+  have horth : ∀ i j : Fin n,
+      ((b i : Fin n → ℝ)) ⬝ᵥ ((b j : Fin n → ℝ)) = if i = j then (1 : ℝ) else 0 := by
+    intro i j
+    rw [dotProduct_comm, ← hinner_eq_dot]
+    have := (orthonormal_iff_ite.mp b.orthonormal) i j
+    simpa using this
+  -- Expand the dot product step by step.
+  rw [hMz_coord, hz_coord, sum_dotProduct]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [smul_dotProduct, dotProduct_sum, smul_eq_mul]
+  have step : ∀ j, (b i : Fin n → ℝ) ⬝ᵥ ((b.repr z j * hH.eigenvalues j) • (b j : Fin n → ℝ))
+      = (b.repr z j * hH.eigenvalues j) * (if i = j then (1 : ℝ) else 0) := by
+    intro j; rw [dotProduct_smul, horth, smul_eq_mul]
+  simp_rw [step]
+  rw [Finset.sum_congr rfl (fun j _ => show
+    (b.repr z j * hH.eigenvalues j) * (if i = j then (1 : ℝ) else 0)
+      = if i = j then b.repr z i * hH.eigenvalues i else 0 by
+    split_ifs with hij
+    · rw [hij]; ring
+    · ring)]
+  rw [Finset.sum_ite_eq Finset.univ i]
+  simp
+  ring
+
+/-- For a Hermitian idempotent real matrix, the number of indices whose eigenvalue is `1`
+equals the rank of the matrix. -/
+lemma card_eigenvalue_one_eq_rank_of_isHermitian_idempotent
+    {n : ℕ} {M : Matrix (Fin n) (Fin n) ℝ}
+    (hH : M.IsHermitian) (hI : IsIdempotentElem M) :
+    (Finset.univ.filter (fun i : Fin n => hH.eigenvalues i = 1)).card = M.rank := by
+  -- Eigenvalues of a Hermitian idempotent real matrix are 0 or 1.
+  have heig : ∀ i : Fin n, hH.eigenvalues i = 0 ∨ hH.eigenvalues i = 1 := fun i => by
+    have hmem := hI.spectrum_subset ℝ (hH.eigenvalues_mem_spectrum_real i)
+    simpa using hmem
+  -- So the "= 1" predicate coincides with the "≠ 0" predicate.
+  have hfilter_eq : Finset.univ.filter (fun i : Fin n => hH.eigenvalues i = 1)
+      = Finset.univ.filter (fun i : Fin n => hH.eigenvalues i ≠ 0) := by
+    ext i
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    constructor
+    · intro h; rw [h]; norm_num
+    · exact (heig i).resolve_left
+  rw [hfilter_eq, hH.rank_eq_card_non_zero_eigs, Fintype.card_subtype]
 
 end HansenEconometrics

--- a/HansenEconometrics/ProbabilityUtils.lean
+++ b/HansenEconometrics/ProbabilityUtils.lean
@@ -1,7 +1,7 @@
 import Mathlib
 
 open MeasureTheory ProbabilityTheory
-open scoped ENNReal Topology MeasureTheory ProbabilityTheory
+open scoped ENNReal Topology MeasureTheory ProbabilityTheory Matrix
 
 namespace HansenEconometrics
 
@@ -87,6 +87,99 @@ theorem integral_apply_apply
       exact integral_apply (μ := μ) (f := fun ω => f ω i) (Integrable.eval hf i) j
 
 end ConditionalExpectationHelpers
+
+section MeanCovariance
+
+open Matrix
+
+variable {Ω k : Type*}
+variable {mΩ : MeasurableSpace Ω}
+variable {μ : Measure Ω}
+variable [Fintype k]
+
+/-- Population mean of a finite-dimensional random vector. -/
+noncomputable def meanVec (μ : Measure Ω) (X : Ω → k → ℝ) : k → ℝ :=
+  ∫ ω, X ω ∂μ
+
+/-- Population covariance vector between a regressor vector `X` and a scalar outcome `Y`. -/
+noncomputable def covVec (μ : Measure Ω) (X : Ω → k → ℝ) (Y : Ω → ℝ) : k → ℝ :=
+  fun i => cov[fun ω => X ω i, Y; μ]
+
+/-- Population covariance matrix of a finite-dimensional regressor vector `X`. -/
+noncomputable def covMat (μ : Measure Ω) (X : Ω → k → ℝ) : Matrix k k ℝ :=
+  fun i j => cov[fun ω => X ω i, fun ω => X ω j; μ]
+
+/-- Integrating a linear form equals applying that linear form to the vector mean. -/
+theorem integral_dotProduct_eq_meanVec_dotProduct
+    (X : Ω → k → ℝ) (b : k → ℝ)
+    (hX : ∀ i, Integrable (fun ω => X ω i) μ) :
+    ∫ ω, dotProduct (X ω) b ∂μ = meanVec μ X ⬝ᵥ b := by
+  simp_rw [dotProduct]
+  rw [integral_finset_sum]
+  · simp_rw [integral_mul_const]
+    refine Finset.sum_congr rfl ?_
+    intro i hi
+    rw [show (∫ ω, X ω i ∂μ) = (meanVec μ X) i by
+      simpa [meanVec] using (MeasureTheory.eval_integral (μ := μ) (f := X) (hf := hX) i).symm]
+  · intro i hi
+    exact (hX i).mul_const (b i)
+
+/-- The covariance vector with a linear form equals the covariance matrix times the coefficient
+vector. -/
+theorem covVec_dotProduct_eq_covMat_mulVec
+    [IsProbabilityMeasure μ]
+    (X : Ω → k → ℝ) (b : k → ℝ)
+    (hX : ∀ i, MemLp (fun ω => X ω i) 2 μ) :
+    covVec μ X (fun ω => dotProduct (X ω) b) = covMat μ X *ᵥ b := by
+  ext i
+  change cov[fun ω => X ω i, fun ω => ∑ j, X ω j * b j; μ] =
+    ∑ j, cov[fun ω => X ω i, fun ω => X ω j; μ] * b j
+  rw [ProbabilityTheory.covariance_fun_sum_right
+      (X := fun j ω => X ω j * b j) (Y := fun ω => X ω i)]
+  · simp_rw [ProbabilityTheory.covariance_mul_const_right]
+  · intro j
+    exact (hX j).mul_const (b j)
+  · exact hX i
+
+/-- Covariances in an affine linear model decompose into the fitted part and the residual part. -/
+theorem covVec_affineModel
+    [IsProbabilityMeasure μ]
+    (X : Ω → k → ℝ) (e : Ω → ℝ) (α : ℝ) (β : k → ℝ)
+    (hX : ∀ i, MemLp (fun ω => X ω i) 2 μ)
+    (he : MemLp e 2 μ) :
+    covVec μ X (fun ω => α + dotProduct (X ω) β + e ω) =
+      covMat μ X *ᵥ β + covVec μ X e := by
+  have hlin : MemLp (fun ω => dotProduct (X ω) β) 2 μ := by
+    classical
+    convert (memLp_finset_sum' (s := Finset.univ) (f := fun j ω => X ω j * β j)
+      (fun j _ => (hX j).mul_const (β j))) using 1
+    ext ω
+    simp [dotProduct]
+  ext i
+  change cov[fun ω => X ω i, fun ω => α + dotProduct (X ω) β + e ω; μ] =
+    (covMat μ X *ᵥ β) i + cov[fun ω => X ω i, e; μ]
+  calc
+    cov[fun ω => X ω i, fun ω => α + dotProduct (X ω) β + e ω; μ]
+        = cov[fun ω => X ω i, fun ω => α + dotProduct (X ω) β; μ] +
+            cov[fun ω => X ω i, e; μ] := by
+              change cov[fun ω => X ω i, (fun ω => α + dotProduct (X ω) β) + e; μ] = _
+              simpa using
+                (ProbabilityTheory.covariance_add_right (X := fun ω => X ω i)
+                  (Y := fun ω => α + dotProduct (X ω) β) (Z := e)
+                  (hX i) ((memLp_const α).add hlin) he)
+    _ = cov[fun ω => X ω i, fun ω => dotProduct (X ω) β; μ] +
+          cov[fun ω => X ω i, e; μ] := by
+            simpa using
+              (ProbabilityTheory.covariance_const_add_right (X := fun ω => X ω i)
+                (Y := fun ω => dotProduct (X ω) β) (μ := μ)
+                (hlin.integrable (by norm_num)) α)
+    _ = (covMat μ X *ᵥ β) i + cov[fun ω => X ω i, e; μ] := by
+          rw [show cov[fun ω => X ω i, fun ω => dotProduct (X ω) β; μ] =
+              (covMat μ X *ᵥ β) i by
+                simpa [covVec] using
+                  congrFun (covVec_dotProduct_eq_covMat_mulVec (μ := μ) X β hX) i]
+
+end MeanCovariance
 
 section ConditioningSpaces
 
@@ -181,5 +274,64 @@ theorem conditioningSpace_le_of_factor
   exact hmeas.comap_le
 
 end ConditioningSpaceFactors
+
+section GaussianCoordinates
+
+variable {n : ℕ} {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (volume : Measure Ω)]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+variable [FiniteDimensional ℝ E] [MeasurableSpace E] [BorelSpace E]
+
+/-- The coordinates of a standard Gaussian vector in an orthonormal basis are i.i.d. standard
+normal. -/
+lemma hasLaw_coords_of_stdGaussian
+    (b : OrthonormalBasis (Fin n) ℝ E)
+    {Z : Ω → E} (hZ : HasLaw Z (stdGaussian E)) :
+    (∀ i, HasLaw (fun ω => b.repr (Z ω) i) (gaussianReal 0 1)) ∧
+      iIndepFun (fun i ω => b.repr (Z ω) i) := by
+  -- Package `b.repr` as a HasLaw via Mathlib's `stdGaussian_map`.
+  have hRepr : HasLaw (fun x : E => (b.repr x : EuclideanSpace ℝ (Fin n)))
+      (stdGaussian (EuclideanSpace ℝ (Fin n))) (stdGaussian E) :=
+    ⟨b.repr.continuous.aemeasurable, stdGaussian_map b.repr⟩
+  have hbZ : HasLaw (fun ω => b.repr (Z ω)) (stdGaussian (EuclideanSpace ℝ (Fin n))) :=
+    hRepr.comp hZ
+  -- Bridge from `stdGaussian` on `EuclideanSpace` to `Measure.pi (fun _ => gaussianReal 0 1)`
+  -- via the `ofLp` coercion (inverse of `toLp 2`).
+  have hm_of : Measurable (WithLp.ofLp : EuclideanSpace ℝ (Fin n) → (Fin n → ℝ)) := by fun_prop
+  have hm_to : Measurable (WithLp.toLp 2 : (Fin n → ℝ) → EuclideanSpace ℝ (Fin n)) := by fun_prop
+  have hOfLp_map : (stdGaussian (EuclideanSpace ℝ (Fin n))).map
+        (WithLp.ofLp : EuclideanSpace ℝ (Fin n) → (Fin n → ℝ))
+      = Measure.pi (fun _ : Fin n => gaussianReal 0 1) := by
+    rw [← map_pi_eq_stdGaussian (ι := Fin n), Measure.map_map hm_of hm_to]
+    simp [Function.comp_def]
+  have hOfLp : HasLaw (fun x : EuclideanSpace ℝ (Fin n) => (x : Fin n → ℝ))
+      (Measure.pi (fun _ : Fin n => gaussianReal 0 1))
+      (stdGaussian (EuclideanSpace ℝ (Fin n))) :=
+    ⟨hm_of.aemeasurable, hOfLp_map⟩
+  have hbZ_coord : HasLaw (fun ω => ((b.repr (Z ω)) : Fin n → ℝ))
+      (Measure.pi (fun _ : Fin n => gaussianReal 0 1)) :=
+    hOfLp.comp hbZ
+  -- Per-coordinate laws via projection through the product measure.
+  have hLaw : ∀ i : Fin n, HasLaw (fun ω => b.repr (Z ω) i) (gaussianReal 0 1) := by
+    intro i
+    refine ⟨hbZ_coord.aemeasurable.eval i, ?_⟩
+    have h1 : (volume : Measure Ω).map (fun ω => b.repr (Z ω) i)
+        = ((volume : Measure Ω).map (fun ω => ((b.repr (Z ω)) : Fin n → ℝ))).map
+            (fun f : Fin n → ℝ => f i) := by
+      rw [AEMeasurable.map_map_of_aemeasurable (measurable_pi_apply i).aemeasurable
+        hbZ_coord.aemeasurable]
+      rfl
+    rw [h1, hbZ_coord.map_eq]
+    exact (measurePreserving_eval (fun _ : Fin n => gaussianReal 0 1) i).map_eq
+  -- Independence via the product-measure characterization.
+  refine ⟨hLaw, ?_⟩
+  rw [iIndepFun_iff_map_fun_eq_pi_map (fun i => (hLaw i).aemeasurable)]
+  rw [show (fun (ω : Ω) (i : Fin n) => b.repr (Z ω) i)
+      = (fun ω => ((b.repr (Z ω)) : Fin n → ℝ)) from rfl]
+  rw [hbZ_coord.map_eq]
+  congr 1
+  funext i
+  exact ((hLaw i).map_eq).symm
+
+end GaussianCoordinates
 
 end HansenEconometrics

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ and `HansenEconometrics/Chapter2LinearProjection.lean`:
   `condVarOn`, and `residualVarOn`
 - coordinatewise conditional-expectation / integral bridge lemmas for finite-dimensional random
   vectors and arrays
+- reusable finite-dimensional mean and covariance helpers `meanVec`, `covVec`, and `covMat`
 - simple law of iterated expectations
 - tower property for nested sigma-algebras
 - tower property in variable-facing form in `Chapter2CondExp.lean`

--- a/notes/ch02/latex_links.md
+++ b/notes/ch02/latex_links.md
@@ -167,8 +167,8 @@ Notes:
 
 Links:
 - [Hansen excerpt](./ch2_excerpt.txt#L1765)
-- [Intercept formula](../../HansenEconometrics/Chapter2LinearProjection.lean#L229)
-- [Slope formula](../../HansenEconometrics/Chapter2LinearProjection.lean#L258)
+- [Intercept formula](../../HansenEconometrics/Chapter2LinearProjection.lean#L160)
+- [Slope formula](../../HansenEconometrics/Chapter2LinearProjection.lean#L189)
 
 | LaTeX | Lean conclusion |
 | --- | --- |
@@ -198,10 +198,12 @@ Hansen's notation and the Lean formalization.
   $\int \operatorname{Var}(Y \mid \mathcal{G}) \, d\mu = \int e^2 \, d\mu$.
 - [`linearProjectionBeta_eq_of_normal_equations`](../../HansenEconometrics/Chapter2LinearProjection.lean#L41):
   solves $Q_{XX} b = Q_{XY}$ as $b = Q_{XX}^{-1} Q_{XY}$.
-- [`integral_dotProduct_eq_meanVec_dotProduct`](../../HansenEconometrics/Chapter2LinearProjection.lean#L158):
+- [`integral_dotProduct_eq_meanVec_dotProduct`](../../HansenEconometrics/ProbabilityUtils.lean#L113):
   $\int X' b \, d\mu = (\int X \, d\mu)' b$.
-- [`covVec_dotProduct_eq_covMat_mulVec`](../../HansenEconometrics/Chapter2LinearProjection.lean#L174):
+- [`covVec_dotProduct_eq_covMat_mulVec`](../../HansenEconometrics/ProbabilityUtils.lean#L129):
   $\operatorname{cov}(X, X' b) = \operatorname{covMat}(X) b$.
-- [`covVec_linearProjectionModel`](../../HansenEconometrics/Chapter2LinearProjection.lean#L191):
+- [`covVec_affineModel`](../../HansenEconometrics/ProbabilityUtils.lean#L145):
+  reusable affine-model covariance decomposition.
+- [`covVec_linearProjectionModel`](../../HansenEconometrics/Chapter2LinearProjection.lean#L149):
   $\operatorname{cov}(X, \alpha + X' \beta + e) = \operatorname{covMat}(X)\beta +
   \operatorname{cov}(X, e)$.


### PR DESCRIPTION
## Summary
- move reusable finite-dimensional mean/covariance helpers into ProbabilityUtils
- move Hermitian/idempotent rank and spectral quadratic-form helpers into LinearAlgebraUtils
- revise ChiSquared and chapter modules to reuse the shared utility layer
- update docs/crosswalks for the new utility ownership

## Verification
- lake build
- git diff --check
- rg -n "sorry|admit|TODO|FIXME" HansenEconometrics/ChiSquared.lean HansenEconometrics/LinearAlgebraUtils.lean HansenEconometrics/ProbabilityUtils.lean HansenEconometrics/Chapter2LinearProjection.lean HansenEconometrics/Chapter3Projections.lean