### PR TITLE
Ch 7 tracer: deterministic core + asymptotic utilities (CMT, Pi decomp, WLLN)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.trace
 *.out
 textextract/
+.mcp.json

--- a/HansenEconometrics.lean
+++ b/HansenEconometrics.lean
@@ -13,3 +13,4 @@ import HansenEconometrics.Chapter3FWL
 import HansenEconometrics.Chapter4LeastSquaresRegression
 import HansenEconometrics.Chapter5NormalRegression
 import HansenEconometrics.ChiSquared
+import HansenEconometrics.Chapter7Asymptotics

--- a/HansenEconometrics.lean
+++ b/HansenEconometrics.lean
@@ -1,6 +1,7 @@
 import HansenEconometrics.Basic
 import HansenEconometrics.LinearAlgebraUtils
 import HansenEconometrics.ProbabilityUtils
+import HansenEconometrics.AsymptoticUtils
 
 import HansenEconometrics.Chapter2CondExp
 

--- a/HansenEconometrics/AsymptoticUtils.lean
+++ b/HansenEconometrics/AsymptoticUtils.lean
@@ -1,0 +1,154 @@
+import Mathlib
+import HansenEconometrics.Basic
+
+/-!
+# Asymptotic utilities: WLLN wrapper and CMT for convergence in measure
+
+This file contains small, reusable lemmas about convergence in probability
+(`TendstoInMeasure`) that Hansen's Chapter 7 consistency proof needs but
+Mathlib does not currently provide as named lemmas:
+
+* `tendstoInMeasure_continuous_comp` — a **continuous-mapping theorem** for
+  `TendstoInMeasure` along `atTop`. If `f n →ₚ g` and `h` is continuous then
+  `h ∘ f n →ₚ h ∘ g`. Proved via Mathlib's subsequence characterization
+  `exists_seq_tendstoInMeasure_atTop_iff`.
+* `tendstoInMeasure_wlln` — a **weak law of large numbers** wrapper: strong
+  law gives a.s. convergence, and in a finite-measure space a.s. convergence
+  implies convergence in measure.
+
+Both are stated for general Banach-space codomains, so they specialize
+directly to scalar, vector, and matrix random variables.
+-/
+
+open MeasureTheory ProbabilityTheory Filter
+open scoped ENNReal Topology MeasureTheory ProbabilityTheory Function
+
+namespace HansenEconometrics
+
+variable {α E F : Type*} {m : MeasurableSpace α} {μ : Measure α}
+
+section CMT
+
+/-- **Continuous mapping theorem for convergence in probability** along `atTop`.
+
+If a sequence `f : ℕ → α → E` of strongly measurable functions converges in
+measure to `g : α → E`, and `h : E → F` is continuous, then
+`fun n ω => h (f n ω)` converges in measure to `fun ω => h (g ω)`.
+
+Proof strategy: Mathlib's `exists_seq_tendstoInMeasure_atTop_iff` says
+`TendstoInMeasure ... atTop ...` is equivalent to "every subsequence has a
+further subsequence that converges almost surely." Continuity lifts almost-sure
+convergence directly; the iff then lifts the whole statement back to
+convergence in measure. -/
+theorem tendstoInMeasure_continuous_comp
+    [IsFiniteMeasure μ]
+    [PseudoEMetricSpace E] [PseudoEMetricSpace F] [TopologicalSpace.PseudoMetrizableSpace F]
+    {f : ℕ → α → E} {g : α → E} {h : E → F}
+    (hf : ∀ n, AEStronglyMeasurable (f n) μ)
+    (hfg : TendstoInMeasure μ f atTop g)
+    (hh : Continuous h) :
+    TendstoInMeasure μ (fun n ω => h (f n ω)) atTop (fun ω => h (g ω)) := by
+  have hhf : ∀ n, AEStronglyMeasurable (fun ω => h (f n ω)) μ :=
+    fun n => hh.comp_aestronglyMeasurable (hf n)
+  rw [exists_seq_tendstoInMeasure_atTop_iff hhf]
+  intro ns hns
+  obtain ⟨ns', hns', hae⟩ := (exists_seq_tendstoInMeasure_atTop_iff hf).mp hfg ns hns
+  refine ⟨ns', hns', ?_⟩
+  filter_upwards [hae] with ω hω
+  exact (hh.tendsto _).comp hω
+
+/-- **Coordinate projection of `TendstoInMeasure`**: if a sequence of `∀ b, X b`-valued
+functions converges in measure, then each coordinate converges in measure.
+
+This is the easy direction of the "Pi ⇔ coordinatewise" characterization. The reverse
+direction (coordinatewise ⇒ joint) is `tendstoInMeasure_pi`. -/
+theorem TendstoInMeasure.pi_apply
+    {β : Type*} [Fintype β] {X : β → Type*} [∀ b, EDist (X b)]
+    {f : ℕ → α → ∀ b, X b} {g : α → ∀ b, X b}
+    (hfg : TendstoInMeasure μ f atTop g) (b : β) :
+    TendstoInMeasure μ (fun n ω => f n ω b) atTop (fun ω => g ω b) := by
+  intro ε hε
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds (hfg ε hε)
+    (fun _ => zero_le _) (fun n => ?_)
+  refine measure_mono (fun ω hω => ?_)
+  exact le_trans hω (edist_le_pi_edist _ _ _)
+
+/-- **Coordinatewise ⇒ joint `TendstoInMeasure`** for Pi types over a `Fintype`:
+if every coordinate sequence converges in measure, so does the joint sequence. -/
+theorem tendstoInMeasure_pi
+    {β : Type*} [Fintype β] {X : β → Type*} [∀ b, EDist (X b)]
+    {f : ℕ → α → ∀ b, X b} {g : α → ∀ b, X b}
+    (h : ∀ b, TendstoInMeasure μ (fun n ω => f n ω b) atTop (fun ω => g ω b)) :
+    TendstoInMeasure μ f atTop g := by
+  intro ε hε
+  have hcover : ∀ n,
+      {ω | ε ≤ edist (f n ω) (g ω)} ⊆ ⋃ b, {ω | ε ≤ edist (f n ω b) (g ω b)} := by
+    intro n ω hω
+    have hω' : ε ≤ Finset.sup Finset.univ (fun b => edist (f n ω b) (g ω b)) := by
+      simpa [edist_pi_def] using hω
+    obtain ⟨b, -, hb⟩ := (Finset.le_sup_iff (bot_lt_iff_ne_bot.mpr hε.ne')).mp hω'
+    exact Set.mem_iUnion.2 ⟨b, hb⟩
+  have hbound : ∀ n,
+      μ {ω | ε ≤ edist (f n ω) (g ω)} ≤
+        ∑ b : β, μ {ω | ε ≤ edist (f n ω b) (g ω b)} := fun n =>
+    (measure_mono (hcover n)).trans
+      (measure_iUnion_fintype_le μ (fun b => {ω | ε ≤ edist (f n ω b) (g ω b)}))
+  have hsum : Tendsto
+      (fun n => ∑ b : β, μ {ω | ε ≤ edist (f n ω b) (g ω b)}) atTop (𝓝 0) := by
+    have : Tendsto (fun n => ∑ b : β, μ {ω | ε ≤ edist (f n ω b) (g ω b)}) atTop
+        (𝓝 (∑ _ : β, (0 : ℝ≥0∞))) :=
+      tendsto_finset_sum Finset.univ (fun b _ => h b ε hε)
+    simpa using this
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds hsum
+    (fun _ => zero_le _) hbound
+
+end CMT
+
+section WLLN
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
+
+/-- **Weak law of large numbers** (Banach-valued, pairwise-independent form).
+
+If `X : ℕ → Ω → E` is a sequence of pairwise-independent, identically distributed,
+integrable `E`-valued random variables on a finite-measure space, then the sample
+mean `(1/n) ∑_{i<n} X i` converges in probability to `𝔼[X 0]`.
+
+This is the direct composition of Mathlib's `strong_law_ae` with
+`tendstoInMeasure_of_tendsto_ae`. Provided here as a named lemma to match the
+econometrics literature's WLLN statement. -/
+theorem tendstoInMeasure_wlln
+    {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    [MeasurableSpace E] [BorelSpace E]
+    [IsFiniteMeasure μ]
+    (X : ℕ → Ω → E)
+    (hint : Integrable (X 0) μ)
+    (hindep : Pairwise ((· ⟂ᵢ[μ] ·) on X))
+    (hident : ∀ i, IdentDistrib (X i) (X 0) μ μ) :
+    TendstoInMeasure μ
+      (fun (n : ℕ) ω => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, X i ω)
+      atTop
+      (fun _ => μ[X 0]) := by
+  have hae : ∀ᵐ ω ∂μ,
+      Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, X i ω) atTop (𝓝 μ[X 0]) :=
+    ProbabilityTheory.strong_law_ae X hint hindep hident
+  have hmeas_each : ∀ i, AEStronglyMeasurable (X i) μ :=
+    fun i => ((hident i).integrable_iff.mpr hint).aestronglyMeasurable
+  have hmeas : ∀ n : ℕ, AEStronglyMeasurable
+      (fun ω => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, X i ω) μ := by
+    intro n
+    have hsum : AEStronglyMeasurable (∑ i ∈ Finset.range n, X i) μ :=
+      Finset.aestronglyMeasurable_sum (Finset.range n) (fun i _ => hmeas_each i)
+    have hscaled := hsum.const_smul ((n : ℝ)⁻¹)
+    have heq : (fun ω => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, X i ω) =
+        ((n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, X i) := by
+      funext ω
+      simp [Finset.sum_apply]
+    rw [heq]
+    exact hscaled
+  exact tendstoInMeasure_of_tendsto_ae hmeas hae
+
+end WLLN
+
+end HansenEconometrics

--- a/HansenEconometrics/Chapter7Asymptotics.lean
+++ b/HansenEconometrics/Chapter7Asymptotics.lean
@@ -1,0 +1,94 @@
+import Mathlib
+import HansenEconometrics.Basic
+import HansenEconometrics.Chapter3LeastSquaresAlgebra
+import HansenEconometrics.Chapter4LeastSquaresRegression
+
+/-!
+# Chapter 7 — Asymptotic Theory (Phase 1 deterministic scaffold)
+
+This file lays the deterministic groundwork for Hansen's asymptotic chapter.
+It introduces the finite-sample empirical moment objects
+
+* `sampleGram X        = Xᵀ X / n`   — sample analogue of `Q := E[X Xᵀ]`
+* `sampleCrossMoment X e = (Xᵀ e) / n` — sample analogue of `E[X e]`
+
+and proves the algebraic identity that is the deterministic engine behind
+Hansen Theorem 7.1 (Consistency of Least Squares):
+
+  β̂ₙ - β = Q̂ₙ⁻¹ *ᵥ g̑ₙ.
+
+No probabilistic infrastructure is imported here beyond what Chapter 4 already
+uses. The iid-sample bridge, WLLN wrapper, and continuous-mapping steps that
+upgrade this identity into `β̂ₙ →ₚ β` live in a separate module and are
+scheduled for Phase 2.
+-/
+
+open scoped Matrix
+
+namespace HansenEconometrics
+
+open Matrix
+
+variable {n k : Type*}
+variable [Fintype n] [Fintype k] [DecidableEq k]
+
+/-- Hansen §7.2: the sample Gram matrix `Q̂ₙ := Xᵀ X / n`. -/
+noncomputable def sampleGram (X : Matrix n k ℝ) : Matrix k k ℝ :=
+  (Fintype.card n : ℝ)⁻¹ • (Xᵀ * X)
+
+/-- Hansen §7.2: the sample cross moment `g̑ₙ := (Xᵀ e) / n`. -/
+noncomputable def sampleCrossMoment (X : Matrix n k ℝ) (e : n → ℝ) : k → ℝ :=
+  (Fintype.card n : ℝ)⁻¹ • (Xᵀ *ᵥ e)
+
+omit [Fintype k] [DecidableEq k] in
+/-- Scaling `Q̂ₙ` by the sample size recovers the unnormalized Gram `Xᵀ X`. -/
+theorem smul_card_sampleGram (X : Matrix n k ℝ) [Nonempty n] :
+    (Fintype.card n : ℝ) • sampleGram X = Xᵀ * X := by
+  have hne : (Fintype.card n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+  unfold sampleGram
+  rw [smul_smul, mul_inv_cancel₀ hne, one_smul]
+
+omit [Fintype k] [DecidableEq k] in
+/-- Scaling `g̑ₙ` by the sample size recovers `Xᵀ e`. -/
+theorem smul_card_sampleCrossMoment (X : Matrix n k ℝ) (e : n → ℝ) [Nonempty n] :
+    (Fintype.card n : ℝ) • sampleCrossMoment X e = Xᵀ *ᵥ e := by
+  have hne : (Fintype.card n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+  unfold sampleCrossMoment
+  rw [smul_smul, mul_inv_cancel₀ hne, one_smul]
+
+/-- If `Xᵀ X` is invertible and the sample is nonempty, `Q̂ₙ` is invertible, with
+inverse `n · (Xᵀ X)⁻¹`. -/
+noncomputable instance sampleGram.invertible
+    (X : Matrix n k ℝ) [Nonempty n] [Invertible (Xᵀ * X)] :
+    Invertible (sampleGram X) := by
+  have hne : (Fintype.card n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+  refine ⟨(Fintype.card n : ℝ) • ⅟ (Xᵀ * X), ?_, ?_⟩
+  · unfold sampleGram
+    rw [Matrix.smul_mul, Matrix.mul_smul, invOf_mul_self,
+        smul_smul, mul_inv_cancel₀ hne, one_smul]
+  · unfold sampleGram
+    rw [Matrix.smul_mul, Matrix.mul_smul, mul_invOf_self,
+        smul_smul, inv_mul_cancel₀ hne, one_smul]
+
+/-- Explicit formula for the inverse of the sample Gram matrix. -/
+theorem invOf_sampleGram
+    (X : Matrix n k ℝ) [Nonempty n] [Invertible (Xᵀ * X)] :
+    ⅟ (sampleGram X) = (Fintype.card n : ℝ) • ⅟ (Xᵀ * X) := rfl
+
+/-- Hansen §7.2 deterministic identity:
+in the linear model `Y = X β + e`, the OLS error decomposes as
+`β̂ₙ - β = Q̂ₙ⁻¹ *ᵥ g̑ₙ`. This is the algebraic engine behind
+Theorem 7.1 (Consistency of Least Squares). -/
+theorem olsBeta_sub_eq_sampleGram_inv_mulVec_sampleCrossMoment
+    (X : Matrix n k ℝ) (β : k → ℝ) (e : n → ℝ)
+    [Nonempty n] [Invertible (Xᵀ * X)] :
+    olsBeta X (X *ᵥ β + e) - β = ⅟ (sampleGram X) *ᵥ sampleCrossMoment X e := by
+  have hne : (Fintype.card n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+  have hcore : olsBeta X (X *ᵥ β + e) - β = (⅟ (Xᵀ * X)) *ᵥ (Xᵀ *ᵥ e) := by
+    rw [olsBeta_linear_decomposition]; abel
+  rw [hcore, invOf_sampleGram]
+  unfold sampleCrossMoment
+  rw [Matrix.smul_mulVec, Matrix.mulVec_smul,
+      smul_smul, mul_inv_cancel₀ hne, one_smul]
+
+end HansenEconometrics

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Legend:
 | 04 | Least Squares Regression | partial | OLS/GLS algebra, unbiasedness, covariance identities, and Gauss-Markov lower bounds landed; HC2/HC3 and clustered SEs deferred |
 | 05 | Normal Regression | partial | normal-model scaffolding, chi-square distribution wrapper, Gaussian laws for `β̂` and residuals, and residual-quadratic-form setup for `s²` landed |
 | 06 | A Review of Large Sample Asymptotics | inventoried | likely prerequisite for later asymptotics chapters |
-| 07 | Asymptotic Theory for Least Squares | inventoried | consistency / asymptotic normality targets |
+| 07 | Asymptotic Theory for Least Squares | partial | Thm 7.1 tracer: sample-moment scaffold and deterministic `β̂ₙ - β = Q̂ₙ⁻¹ g̑ₙ` identity landed; probabilistic bridge pending |
 | 08 | Restricted Estimation | inventoried | constrained estimation / minimum distance |
 | 09 | Hypothesis Testing | inventoried | Wald / LM / LR style results |
 | 10 | Resampling Methods | inventoried | bootstrap / jackknife |

--- a/notes/asymptotics_mathlib_audit.md
+++ b/notes/asymptotics_mathlib_audit.md
@@ -35,6 +35,62 @@ Caveats worth noting:
 4. **Delta Method** — not present as a named theorem. Straightforward via CMT + Fréchet derivative; not blocking until late Ch 7.
 5. **Quadratic form of standard normal under symmetric idempotent → χ²(rank)** — not present. **Load-bearing missing piece for Chapter 5.** Construction: spectral decomposition of `M` (eigenvalues 0 / 1, `M = U diag(1,…,1,0,…,0) Uᵀ`), giving `eᵀ M e = ∑_{i ≤ r} (Uᵀe)_iˆ²`, a sum of `r` iid standard normal squares = χ²(r). Needs χ²(k) defined first, plus the additivity / sum-of-squares lemmas (Gamma additivity is likely already in Mathlib — worth a quick confirm).
 
+## Phase 2 spike findings (Ch 7 consistency)
+
+Second pass, focused on the chain behind Theorem 7.1 (`β̂ₙ →ₚ β`).
+
+**Present and usable as-is:**
+
+| Item | File:line | Notes |
+|---|---|---|
+| `ProbabilityTheory.strong_law_ae` | `Mathlib/Probability/StrongLaw.lean:788` | Works in any Banach space `E` (real or vector); consumes `Pairwise ((· ⟂ᵢ[μ] ·) on X)` and `IdentDistrib`. |
+| `MeasureTheory.tendstoInMeasure_of_tendsto_ae` | `Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean:223` | Needs `[IsFiniteMeasure μ]` and `AEStronglyMeasurable`. Bridges SLLN → convergence-in-measure. |
+| `exists_seq_tendstoInMeasure_atTop_iff` | `Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean:339` | Characterizes `TendstoInMeasure ... atTop` by every-subsequence-has-a.s.-convergent-subsubsequence. This is the lever for a CMT wrapper. |
+| `NormedRing.inverse_continuousAt` | `Mathlib/Analysis/Normed/Ring/Units.lean` (general Banach algebra) | For matrix inversion at an invertible matrix: specialize to `Matrix n n ℝ` with a Banach-algebra-compatible norm. |
+| `Continuous.matrix_mulVec` | `Mathlib/Topology/Instances/Matrix.lean:169` | Direct continuity of `(A, v) ↦ A *ᵥ v`. Closes the matrix-vector step of the CMT chain. |
+| Scoped matrix norms | `Mathlib/Analysis/Matrix/Normed.lean` | `Matrix.Norms.Frobenius`, `Matrix.Norms.L2Operator`, `Matrix.Norms.Elementwise` — pick one scope to unlock the Banach structure needed by `strong_law_ae`. |
+
+**Not in Mathlib — must wrap:**
+
+1. **CMT for `TendstoInMeasure`.** There is no `TendstoInMeasure.continuous_comp`. `TendstoInMeasure.comp` only composes with the *index* filter, not with a function on the codomain. The subsequence-characterization (`exists_seq_tendstoInMeasure_atTop_iff`) gives a clean route: every subsequence has an a.s.-convergent sub-subsequence, continuity lifts a.s. convergence, and the iff closes the loop.
+
+2. **Pi-decomposition of `TendstoInMeasure`.** No `TendstoInMeasure μ f l g ↔ ∀ j, TendstoInMeasure μ (·.j) l g.j` for `Fintype`-indexed Pi types. Needs a short bespoke proof; the `←` direction composes through `Finset`-sum of ball measures, the `→` direction is component-projection continuity + CMT wrapper above.
+
+3. **Arithmetic of `TendstoInMeasure`.** No named `TendstoInMeasure.add`, `.mul`, `.smul`. Once the generic CMT wrapper lands, `.add` etc. follow by continuity of `+`, `·`, `•`.
+
+4. **No WLLN named lemma.** But `tendstoInMeasure_of_tendsto_ae ∘ strong_law_ae` is a direct one-liner.
+
+**Architectural decision:** build the missing utilities as a standalone `HansenEconometrics/AsymptoticUtils.lean`, then use them in `Chapter7Asymptotics.lean`. The CMT wrapper + Pi-decomposition are reusable well beyond Hansen and are reasonable upstream-PR candidates for Mathlib later.
+
+**Matrix norm scope choice:** the `Elementwise` norm (sup of entry norms) is the most natural match for entry-wise WLLN arguments. But since the SLLN chain works in any Banach space, Frobenius is equally fine. Pick one globally at the top of `Chapter7Asymptotics.lean` via `open scoped Matrix.Norms.Frobenius` (or Elementwise) — consistency matters more than the choice itself.
+
+### Phase 2 utilities landed (`HansenEconometrics/AsymptoticUtils.lean`)
+
+| Utility | Lean name | Role |
+|---|---|---|
+| CMT for convergence in measure along `atTop` | `HansenEconometrics.tendstoInMeasure_continuous_comp` | For continuous `h : E → F` and `f n →ₚ g`, yields `h ∘ f n →ₚ h ∘ g`. Proved via the subsequence characterization. |
+| Pi-decomposition (joint ⇒ coordinate) | `HansenEconometrics.TendstoInMeasure.pi_apply` | `f n →ₚ g` on `∀ b, X b` implies each `(f n · b) →ₚ (g · b)`. Follows from `edist_le_pi_edist`. |
+| Pi-decomposition (coordinate ⇒ joint) | `HansenEconometrics.tendstoInMeasure_pi` | Coordinatewise convergence in measure on a `Fintype`-indexed Pi type gives joint convergence. Uses `Finset.le_sup_iff` and finite-union measure bound. |
+| WLLN for Banach-valued iid | `HansenEconometrics.tendstoInMeasure_wlln` | Direct composition of `strong_law_ae` and `tendstoInMeasure_of_tendsto_ae`. Works for scalar, vector-, and matrix-valued targets on any Banach space. |
+
+### What's still missing for Theorem 7.1
+
+The remaining chain to close `β̂ₙ →ₚ β`:
+
+1. **iid-sample representation.** Decide the shape: per-observation regressor `X : ℕ → Ω → (k → ℝ)` plus error `e : ℕ → Ω → ℝ`, with the pair packaged as an iid sequence. Define empirical moments `Q̂ₙ(ω) = (1/n) ∑ Xᵢ Xᵢᵀ(ω)` and `g̑ₙ(ω) = (1/n) ∑ eᵢ Xᵢ(ω)` directly from the sum (no design-matrix stacking needed for the consistency argument).
+
+2. **Matrix-valued WLLN for `Q̂ₙ →ₚ Q`.** Apply `tendstoInMeasure_wlln` to `Xᵢ Xᵢᵀ : Ω → Matrix k k ℝ` under an appropriate matrix Banach norm (Frobenius or Elementwise). Requires `Integrable (X 0 · X 0ᵀ)` — i.e., `E[Xᵢ Xᵢᵀ]` exists entry-wise, which follows from `Xᵢⱼ ∈ L²`.
+
+3. **Vector-valued WLLN for `g̑ₙ →ₚ 0`.** Same pattern on `fun ω => eᵢ ω • Xᵢ ω : Ω → (k → ℝ)`, under `E[Xᵢ eᵢ] = 0`.
+
+4. **CMT for matrix inversion.** Apply `tendstoInMeasure_continuous_comp` with `h = Ring.inverse` (or `Matrix.inv`) at `Q`. The continuity input comes from `NormedRing.inverse_continuousAt` specialized to matrices. Care: `Ring.inverse` agrees with `⅟` only on units, and at non-invertible matrices returns 0 — need to argue the sample is eventually in the invertible neighborhood, or restrict the result to "on the set where `Q̂ₙ` is invertible."
+
+5. **CMT for matrix-vector multiplication.** Compose `Q̂ₙ⁻¹ *ᵥ g̑ₙ →ₚ Q⁻¹ *ᵥ 0 = 0` via `Continuous.matrix_mulVec` and `tendstoInMeasure_continuous_comp` on the joint pair `(Q̂ₙ⁻¹, g̑ₙ)`. This also needs a "jointly continuous map" variant or a two-step reduction.
+
+6. **Deterministic ⇒ probabilistic bridge.** The `Chapter7Asymptotics.lean` identity `β̂ₙ - β = Q̂ₙ⁻¹ *ᵥ g̑ₙ` is expressed using the `Matrix (Fin n) k ℝ` design matrix. To use it with iid-indexed sample moments, either (a) prove that for every `ω` with invertible `Q̂ₙ(ω)`, `betaHatₙ(ω) = β + Q̂ₙ⁻¹(ω) *ᵥ g̑ₙ(ω)` directly from the sum-of-outer-products form, or (b) connect via a stacking equivalence `Matrix (Fin n) k ℝ(ω) = stack (X · ω)`. Option (a) avoids the stacking plumbing entirely.
+
+Step 6 is the most delicate piece architecturally — choose (a) to keep the asymptotics argument independent of `Matrix (Fin n) k ℝ` entirely, at the cost of re-proving the algebraic identity for sample-moment-expressed `betaHatₙ`.
+
 ## Proposed order of attack
 
 1. Define `chiSquared k` as a `gammaMeasure` wrapper + minimal API.


### PR DESCRIPTION
## Summary

Chapter 7 tracer-bullet work aimed at Theorem 7.1 (Consistency of Least Squares). Lands in two layers:

- **Deterministic core** in `HansenEconometrics/Chapter7Asymptotics.lean`: sample moments `sampleGram`, `sampleCrossMoment`, the scaling bridges, an `Invertible (sampleGram X)` instance, and the identity `β̂ₙ − β = Q̂ₙ⁻¹ *ᵥ g̑ₙ`. Reduces to the Ch 4 decomposition; no probability imports.
- **Asymptotic utilities** in `HansenEconometrics/AsymptoticUtils.lean`: four reusable lemmas for convergence in probability that Mathlib does not expose as named results.

## What's in `AsymptoticUtils.lean`

| Lemma | Role |
|---|---|
| `tendstoInMeasure_continuous_comp` | Continuous mapping theorem for `TendstoInMeasure` along `atTop`. Proved via Mathlib's subsequence characterization `exists_seq_tendstoInMeasure_atTop_iff`. |
| `TendstoInMeasure.pi_apply` | Joint convergence ⇒ coordinatewise convergence on a `Fintype`-indexed Pi type. Uses `edist_le_pi_edist`. |
| `tendstoInMeasure_pi` | Coordinatewise convergence ⇒ joint. `Finset.le_sup_iff` + finite-union measure bound. |
| `tendstoInMeasure_wlln` | Banach-valued WLLN. Direct composition of `ProbabilityTheory.strong_law_ae` with `tendstoInMeasure_of_tendsto_ae`. |

All four are stated for general Banach-space (or `PseudoEMetricSpace`) codomains so they specialize to scalar, vector, and matrix random variables without rewrapping.

## Design notes

- `Chapter7Asymptotics.lean` is Phase 1 — purely algebraic, no probability. The split from the probability chain is deliberate: it pinned down the representation choices (`Matrix n k ℝ`, `[Nonempty n]`, `[Invertible (Xᵀ * X)]`) before committing to an iid-sample shape.
- `AsymptoticUtils.lean` is a new module because the material is reusable beyond Ch 7 (anywhere a Mathlib-facing CMT / WLLN wrapper helps) and has a distinct audience from `ProbabilityUtils.lean`'s variable-conditioned helpers. Per `AGENTS.md § Module boundary policy`.
- `notes/asymptotics_mathlib_audit.md` is extended with a Phase 2 spike: what Mathlib provides directly (`strong_law_ae`, `NormedRing.inverse_continuousAt`, `Continuous.matrix_mulVec`, scoped matrix Banach norms), what these utilities wrap, and the remaining six-step punch list to close `β̂ₙ →ₚ β`.
- `.mcp.json` added to `.gitignore` since it's local tooling state, not project config.

## What's explicitly not here

- **iid-sample bridge.** Representation choice is still open — the audit note argues for per-observation sums (`X : ℕ → Ω → (k → ℝ)`, `e : ℕ → Ω → ℝ`) over stacked `Matrix (Fin n) k ℝ`, but doesn't commit.
- **Theorem 7.1 proof.** Six-step chain (entry-wise WLLN → `tendstoInMeasure_pi` → matrix/vector WLLN → CMT for inverse → CMT for `mulVec` → deterministic identity) laid out in the audit but not assembled.

## Test plan

- [x] `lake build` green on top of `mostlyharmfuleconometrics/main` (8263/8263 jobs, pre-existing Ch 5 line-length warning only)
- [x] `Chapter7Asymptotics.lean` has zero sorries
- [x] `AsymptoticUtils.lean` has zero sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)