### PR TITLE
Consolidate HC2/HC3 leverage-norm convergence proofs (closes #32) + update Chapter 6 inventory

### DIFF
--- a/HansenEconometrics/Chapter7Asymptotics/MiddleConsistency.lean
+++ b/HansenEconometrics/Chapter7Asymptotics/MiddleConsistency.lean
@@ -307,62 +307,101 @@ theorem hc3Weight_abs_sub_one_le_eight_mul
         nlinarith
       nlinarith
 
-/-- If the maximal leverage is smaller than `δ ≤ 1/2`, then the HC2
-adjustment-weight norm is smaller than `2δ`. -/
-theorem levAdjWtNormStar_hc2_lt_maxLevStar_lt
-    (X : Matrix n k ℝ) {δ : ℝ} (hδ : 0 < δ) (hδ_half : δ ≤ 1 / 2)
+/-- If a leverage weight satisfies `|w(h) - 1| ≤ C · h` on `[0, 1/2]` and
+maximal leverage is below `δ ≤ 1/2`, then the leverage-adjustment weight norm is bounded
+by `C · δ`. Backend helper for per-family weight-norm convergence wrappers. -/
+private theorem levAdjWtNormStar_le_of_linearBound
+    (X : Matrix n k ℝ) (weight : ℝ → ℝ) {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ {h : ℝ}, 0 ≤ h → h ≤ 1 / 2 → |weight h - 1| ≤ C * h)
+    {δ : ℝ} (hδ_nonneg : 0 ≤ δ) (hδ_half : δ ≤ 1 / 2)
     (hmax : maxLeverageStar X < δ) :
-    levAdjWtNormStar (fun h => (1 - h)⁻¹) X < 2 * δ := by
-  let z : n → ℝ := fun i => (1 - leverageStar X i)⁻¹ - 1
+    levAdjWtNormStar weight X ≤ C * δ := by
+  let z : n → ℝ := fun i => weight (leverageStar X i) - 1
   have hcoords : ∀ i : n, leverageStar X i < δ := by
     intro i
     exact lt_of_le_of_lt (leverageStar_le_maxLeverageStar X i) hmax
-  have hz : ‖z‖ < 2 * δ := by
+  have hz : ‖z‖ ≤ C * δ := by
     refine
-      (@pi_norm_lt_iff n (fun _ : n => ℝ) _
-        (fun _ => (by infer_instance : SeminormedAddGroup ℝ)) z (2 * δ)
-        (show 0 < 2 * δ by positivity)).2 ?_
+      (@pi_norm_le_iff_of_nonneg n (fun _ : n => ℝ) _
+        (fun _ => (by infer_instance : SeminormedAddGroup ℝ)) z (C * δ)
+        (mul_nonneg hC hδ_nonneg)).2 ?_
     intro i
     have hi_nonneg : 0 ≤ leverageStar X i := leverageStar_nonneg X i
     have hi_lt : leverageStar X i < δ := hcoords i
     have hi_half : leverageStar X i ≤ 1 / 2 := by
       linarith
-    have hbound :
-        |(1 - leverageStar X i)⁻¹ - 1| ≤ 2 * leverageStar X i :=
-      hc2Weight_abs_sub_one_le_two_mul hi_nonneg hi_half
-    have hlt : 2 * leverageStar X i < 2 * δ := by
-      exact mul_lt_mul_of_pos_left hi_lt (by positivity)
-    simpa [z, Real.norm_eq_abs] using lt_of_le_of_lt hbound hlt
+    have hweight : |weight (leverageStar X i) - 1| ≤ C * leverageStar X i :=
+      hbound hi_nonneg hi_half
+    have hlev : C * leverageStar X i ≤ C * δ := by
+      exact mul_le_mul_of_nonneg_left (le_of_lt hi_lt) hC
+    simpa [z, Real.norm_eq_abs] using hweight.trans hlev
   simpa [levAdjWtNormStar, z] using hz
 
-/-- If the maximal leverage is smaller than `δ ≤ 1/2`, then the HC3
-adjustment-weight norm is smaller than `8δ`. -/
-theorem levAdjWtNormStar_hc3_lt_maxLevStar_lt
-    (X : Matrix n k ℝ) {δ : ℝ} (hδ : 0 < δ) (hδ_half : δ ≤ 1 / 2)
-    (hmax : maxLeverageStar X < δ) :
-    levAdjWtNormStar (fun h => ((1 - h)⁻¹) ^ 2) X < 8 * δ := by
-  let z : n → ℝ := fun i => ((1 - leverageStar X i) ^ 2)⁻¹ - 1
-  have hcoords : ∀ i : n, leverageStar X i < δ := by
-    intro i
-    exact lt_of_le_of_lt (leverageStar_le_maxLeverageStar X i) hmax
-  have hz : ‖z‖ < 8 * δ := by
-    refine
-      (@pi_norm_lt_iff n (fun _ : n => ℝ) _
-        (fun _ => (by infer_instance : SeminormedAddGroup ℝ)) z (8 * δ)
-        (show 0 < 8 * δ by positivity)).2 ?_
-    intro i
-    have hi_nonneg : 0 ≤ leverageStar X i := leverageStar_nonneg X i
-    have hi_lt : leverageStar X i < δ := hcoords i
-    have hi_half : leverageStar X i ≤ 1 / 2 := by
+/-- A linear-in-leverage bound `|w(h) - 1| ≤ C · h` on `[0, 1/2]` upgrades
+`oₚ(1)` maximal leverage to `oₚ(1)` leverage-adjustment weight norm. Backend helper
+for per-family weight-norm convergence wrappers. -/
+private theorem levAdjWtNormStar_tendstoInMeasure_zero_of_linearBound
+    {μ : Measure Ω} {X : ℕ → Ω → (k → ℝ)} (weight : ℝ → ℝ)
+    {C : ℝ} (hC : 0 < C)
+    (hbound : ∀ {h : ℝ}, 0 ≤ h → h ≤ 1 / 2 → |weight h - 1| ≤ C * h)
+    (hMax : TendstoInMeasure μ
+      (fun n ω => maxLeverageStar (stackRegressors X n ω))
+      atTop (fun _ => 0)) :
+    TendstoInMeasure μ
+      (fun n ω => levAdjWtNormStar weight (stackRegressors X n ω))
+      atTop (fun _ => 0) := by
+  rw [tendstoInMeasure_iff_dist] at hMax ⊢
+  intro ε hε
+  rw [ENNReal.tendsto_atTop_zero]
+  intro η hη
+  let δ : ℝ := min (1 / 4 : ℝ) (ε / (2 * C))
+  have hδ : 0 < δ := by
+    dsimp [δ]
+    refine lt_min ?_ ?_
+    · norm_num
+    · positivity
+  have hδ_nonneg : 0 ≤ δ := le_of_lt hδ
+  have hδ_half : δ ≤ 1 / 2 := by
+    dsimp [δ]
+    have hle : min (1 / 4 : ℝ) (ε / (2 * C)) ≤ 1 / 4 := min_le_left _ _
+    linarith
+  have hCδ_lt_ε : C * δ < ε := by
+    dsimp [δ]
+    have hle : min (1 / 4 : ℝ) (ε / (2 * C)) ≤ ε / (2 * C) := min_le_right _ _
+    have hmul : C * min (1 / 4 : ℝ) (ε / (2 * C)) ≤ C * (ε / (2 * C)) := by
+      exact mul_le_mul_of_nonneg_left hle hC.le
+    have hhalf : C * (ε / (2 * C)) = ε / 2 := by
+      field_simp [hC.ne']
+    have hgap : ε / 2 < ε := by
       linarith
-    have hbound :
-        |((1 - leverageStar X i) ^ 2)⁻¹ - 1| ≤ 8 * leverageStar X i := by
-      simpa [pow_two] using
-        (hc3Weight_abs_sub_one_le_eight_mul (h := leverageStar X i) hi_nonneg hi_half)
-    have hlt : 8 * leverageStar X i < 8 * δ := by
-      exact mul_lt_mul_of_pos_left hi_lt (by positivity)
-    simpa [z, Real.norm_eq_abs] using lt_of_le_of_lt hbound hlt
-  simpa [levAdjWtNormStar, z, pow_two] using hz
+    exact lt_of_le_of_lt (by simpa [hhalf] using hmul) hgap
+  have hMaxevent := (hMax δ hδ).eventually_lt_const hη
+  obtain ⟨N, hN⟩ := eventually_atTop.1 hMaxevent
+  refine ⟨N, fun n hn => ?_⟩
+  have hMaxn : μ {ω | δ ≤ dist (maxLeverageStar (stackRegressors X n ω)) 0} < η :=
+    hN n hn
+  have hcover :
+      {ω | ε ≤ dist
+          (levAdjWtNormStar weight (stackRegressors X n ω)) 0} ⊆
+        {ω | δ ≤ dist (maxLeverageStar (stackRegressors X n ω)) 0} := by
+    intro ω hω
+    by_contra hsmall
+    have hmax_lt : maxLeverageStar (stackRegressors X n ω) < δ := by
+      have hdist_lt : dist (maxLeverageStar (stackRegressors X n ω)) 0 < δ :=
+        not_le.mp hsmall
+      simpa [Real.dist_eq, maxLeverageStar, abs_of_nonneg (norm_nonneg _)] using hdist_lt
+    have hweight_le :
+        levAdjWtNormStar weight (stackRegressors X n ω) ≤ C * δ :=
+      levAdjWtNormStar_le_of_linearBound
+        (X := stackRegressors X n ω) (weight := weight) hC.le hbound
+        hδ_nonneg hδ_half hmax_lt
+    have hdist_lt :
+        dist (levAdjWtNormStar weight (stackRegressors X n ω)) 0 < ε := by
+      simpa [Real.dist_eq, levAdjWtNormStar,
+        abs_of_nonneg (norm_nonneg _)] using
+        lt_of_le_of_lt hweight_le hCδ_lt_ε
+    exact (not_le_of_gt hdist_lt) hω
+  exact le_of_lt (lt_of_le_of_lt (measure_mono hcover) hMaxn)
 
 /-- HC2 adjustment-weight norms are `oₚ(1)` once maximal leverage is `oₚ(1)`. -/
 theorem levAdjWtNormStar_hc2_tendstoInMeasure_zero_maxLevStar
@@ -374,56 +413,11 @@ theorem levAdjWtNormStar_hc2_tendstoInMeasure_zero_maxLevStar
       (fun n ω =>
         levAdjWtNormStar (fun h => (1 - h)⁻¹)
           (stackRegressors X n ω))
-      atTop (fun _ => 0) := by
-  rw [tendstoInMeasure_iff_dist] at hMax ⊢
-  intro ε hε
-  rw [ENNReal.tendsto_atTop_zero]
-  intro η hη
-  let δ : ℝ := min (1 / 4 : ℝ) (ε / 4)
-  have hδ : 0 < δ := by
-    dsimp [δ]
-    refine lt_min ?_ ?_
-    · norm_num
-    · positivity
-  have hδ_half : δ ≤ 1 / 2 := by
-    dsimp [δ]
-    have hle : min (1 / 4 : ℝ) (ε / 4) ≤ 1 / 4 := min_le_left _ _
-    linarith
-  have htwoδ_lt_ε : 2 * δ < ε := by
-    dsimp [δ]
-    have hle : min (1 / 4 : ℝ) (ε / 4) ≤ ε / 4 := min_le_right _ _
-    nlinarith
-  have hMaxevent := (hMax δ hδ).eventually_lt_const hη
-  obtain ⟨N, hN⟩ := eventually_atTop.1 hMaxevent
-  refine ⟨N, fun n hn => ?_⟩
-  have hMaxn : μ {ω | δ ≤ dist (maxLeverageStar (stackRegressors X n ω)) 0} < η :=
-    hN n hn
-  have hcover :
-      {ω | ε ≤ dist
-          (levAdjWtNormStar (fun h => (1 - h)⁻¹)
-            (stackRegressors X n ω)) 0} ⊆
-        {ω | δ ≤ dist (maxLeverageStar (stackRegressors X n ω)) 0} := by
-    intro ω hω
-    by_contra hsmall
-    have hmax_lt : maxLeverageStar (stackRegressors X n ω) < δ := by
-      have hdist_lt : dist (maxLeverageStar (stackRegressors X n ω)) 0 < δ :=
-        not_le.mp hsmall
-      simpa [Real.dist_eq, maxLeverageStar, abs_of_nonneg (norm_nonneg _)] using hdist_lt
-    have hweight_lt :
-        levAdjWtNormStar (fun h => (1 - h)⁻¹)
-          (stackRegressors X n ω) < 2 * δ :=
-      levAdjWtNormStar_hc2_lt_maxLevStar_lt
-        (X := stackRegressors X n ω) hδ hδ_half hmax_lt
-    have hdist_lt :
-        dist
-            (levAdjWtNormStar (fun h => (1 - h)⁻¹)
-              (stackRegressors X n ω))
-            0 < ε := by
-      simpa [Real.dist_eq, levAdjWtNormStar,
-        abs_of_nonneg (norm_nonneg _)] using
-        lt_trans hweight_lt htwoδ_lt_ε
-    exact (not_le_of_gt hdist_lt) hω
-  exact le_of_lt (lt_of_le_of_lt (measure_mono hcover) hMaxn)
+      atTop (fun _ => 0) :=
+  levAdjWtNormStar_tendstoInMeasure_zero_of_linearBound
+    (weight := fun h => (1 - h)⁻¹) (C := 2) (by norm_num)
+    (fun {h} hh_nonneg hh_half =>
+      hc2Weight_abs_sub_one_le_two_mul hh_nonneg hh_half) hMax
 
 /-- HC3 adjustment-weight norms are `oₚ(1)` once maximal leverage is `oₚ(1)`. -/
 theorem levAdjWtNormStar_hc3_tendstoInMeasure_zero_maxLevStar
@@ -435,56 +429,11 @@ theorem levAdjWtNormStar_hc3_tendstoInMeasure_zero_maxLevStar
       (fun n ω =>
         levAdjWtNormStar (fun h => ((1 - h)⁻¹) ^ 2)
           (stackRegressors X n ω))
-      atTop (fun _ => 0) := by
-  rw [tendstoInMeasure_iff_dist] at hMax ⊢
-  intro ε hε
-  rw [ENNReal.tendsto_atTop_zero]
-  intro η hη
-  let δ : ℝ := min (1 / 4 : ℝ) (ε / 16)
-  have hδ : 0 < δ := by
-    dsimp [δ]
-    refine lt_min ?_ ?_
-    · norm_num
-    · positivity
-  have hδ_half : δ ≤ 1 / 2 := by
-    dsimp [δ]
-    have hle : min (1 / 4 : ℝ) (ε / 16) ≤ 1 / 4 := min_le_left _ _
-    linarith
-  have heightδ_lt_ε : 8 * δ < ε := by
-    dsimp [δ]
-    have hle : min (1 / 4 : ℝ) (ε / 16) ≤ ε / 16 := min_le_right _ _
-    nlinarith
-  have hMaxevent := (hMax δ hδ).eventually_lt_const hη
-  obtain ⟨N, hN⟩ := eventually_atTop.1 hMaxevent
-  refine ⟨N, fun n hn => ?_⟩
-  have hMaxn : μ {ω | δ ≤ dist (maxLeverageStar (stackRegressors X n ω)) 0} < η :=
-    hN n hn
-  have hcover :
-      {ω | ε ≤ dist
-          (levAdjWtNormStar (fun h => ((1 - h)⁻¹) ^ 2)
-            (stackRegressors X n ω)) 0} ⊆
-        {ω | δ ≤ dist (maxLeverageStar (stackRegressors X n ω)) 0} := by
-    intro ω hω
-    by_contra hsmall
-    have hmax_lt : maxLeverageStar (stackRegressors X n ω) < δ := by
-      have hdist_lt : dist (maxLeverageStar (stackRegressors X n ω)) 0 < δ :=
-        not_le.mp hsmall
-      simpa [Real.dist_eq, maxLeverageStar, abs_of_nonneg (norm_nonneg _)] using hdist_lt
-    have hweight_lt :
-        levAdjWtNormStar (fun h => ((1 - h)⁻¹) ^ 2)
-          (stackRegressors X n ω) < 8 * δ :=
-      levAdjWtNormStar_hc3_lt_maxLevStar_lt
-        (X := stackRegressors X n ω) hδ hδ_half hmax_lt
-    have hdist_lt :
-        dist
-            (levAdjWtNormStar (fun h => ((1 - h)⁻¹) ^ 2)
-              (stackRegressors X n ω))
-            0 < ε := by
-      simpa [Real.dist_eq, levAdjWtNormStar,
-        abs_of_nonneg (norm_nonneg _)] using
-        lt_trans hweight_lt heightδ_lt_ε
-    exact (not_le_of_gt hdist_lt) hω
-  exact le_of_lt (lt_of_le_of_lt (measure_mono hcover) hMaxn)
+      atTop (fun _ => 0) :=
+  levAdjWtNormStar_tendstoInMeasure_zero_of_linearBound
+    (weight := fun h => ((1 - h)⁻¹) ^ 2) (C := 8) (by norm_num)
+    (fun {h} hh_nonneg hh_half =>
+      hc3Weight_abs_sub_one_le_eight_mul hh_nonneg hh_half) hMax
 
 /-- The residual absolute-weight average is nonnegative. -/
 theorem sampleScoreCovResAbsWtStar_nonneg

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Legend:
 | 03 | The Algebra of Least Squares | partial | OLS algebra + projection/annihilator (incl. rank) / FWL coefficient and residual core landed |
 | 04 | Least Squares Regression | partial | OLS/GLS algebra, unbiasedness, covariance identities, and Gauss-Markov lower bounds landed; HC2/HC3 and clustered SEs deferred |
 | 05 | Normal Regression | partial | normal-model scaffolding, chi-square distribution wrapper, Gaussian laws for `β̂` and residuals, and residual-quadratic-form setup for `s²` landed |
-| 06 | A Review of Large Sample Asymptotics | inventoried | likely prerequisite for later asymptotics chapters |
-| 07 | Asymptotic Theory for Least Squares | partial | Theorem 7.1 totalized/ordinary-on-nonsingular consistency landed; Theorem 7.2 projection-family score CLT plus score-covariance `Ω` wrappers landed; Theorem 7.3 projection-family CLT covers totalized and ordinary-on-nonsingular OLS; Theorems 7.4 and 7.5 totalized variance/covariance consistency landed; vector/Cramér-Wold packaging pending |
+| 06 | A Review of Large Sample Asymptotics | partial | WLLN, CLT (via Cramér–Wold), CMT in probability, O_p/o_p, Slutsky already backed by Mathlib + AsymptoticUtils.lean; outstanding theorems tracked in #41 |
+| 07 | Asymptotic Theory for Least Squares | partial | Theorem 7.1 totalized/ordinary-on-nonsingular consistency landed; Theorem 7.2 projection-family score CLT plus score-covariance `Ω` wrappers landed; Theorem 7.3 projection-family CLT covers totalized and ordinary-on-nonsingular OLS; Theorems 7.4 and 7.5 totalized variance/covariance consistency landed |
 | 08 | Restricted Estimation | inventoried | constrained estimation / minimum distance |
 | 09 | Hypothesis Testing | inventoried | Wald / LM / LR style results |
 | 10 | Resampling Methods | inventoried | bootstrap / jackknife |

--- a/inventory/ch6-inventory.md
+++ b/inventory/ch6-inventory.md
@@ -45,7 +45,7 @@
 4. Add the needed measure/probability infrastructure before attempting the main stochastic theorem.
 
 ## Status
-- not started
+- partial — load-bearing Mathlib + AsymptoticUtils backing in place; outstanding theorems tracked in #41
 
 ## LaTeX / Lean Crosswalk
 
@@ -64,26 +64,42 @@ Conventions:
 
 | Textbook result | LaTeX | Lean theorem |
 | --- | --- | --- |
-| Theorem 6.1 Weak Law of Large Numbers | If $Y_i \in \mathbb{R}^k$ are i.i.d. and $\mathbb{E}\|Y\| < \infty$, then $\bar{Y} = \frac{1}{n} \sum_{i=1}^n Y_i \xrightarrow{p} \mathbb{E}[Y]$ |  |
-| Theorem 6.2 transformed WLLN | If $Y_i \in \mathbb{R}^k$ are i.i.d., $h : \mathbb{R}^k \to \mathbb{R}^q$, and $\mathbb{E}\|h(Y)\| < \infty$, then $\hat{\mu} = \frac{1}{n} \sum_{i=1}^n h(Y_i) \xrightarrow{p} \mu = \mathbb{E}[h(Y)]$ |  |
+| Theorem 6.1 Weak Law of Large Numbers | If $Y_i \in \mathbb{R}^k$ are i.i.d. and $\mathbb{E}\lVert Y \rVert < \infty$, then $\bar{Y} = \frac{1}{n} \sum_{i=1}^n Y_i \xrightarrow{p} \mathbb{E}[Y]$ | [tendstoInMeasure_wlln](../HansenEconometrics/AsymptoticUtils.lean#L896) — Banach-valued; upgrades Mathlib's `ProbabilityTheory.strong_law_ae` to convergence in measure. |
+| Theorem 6.2 transformed WLLN | If $Y_i \in \mathbb{R}^k$ are i.i.d., $h : \mathbb{R}^k \to \mathbb{R}^q$, and $\mathbb{E}\lVert h(Y) \rVert < \infty$, then $\hat{\mu} = \frac{1}{n} \sum_{i=1}^n h(Y_i) \xrightarrow{p} \mu = \mathbb{E}[h(Y)]$ |  |
 | Definition 6.3 consistency | $\hat{\theta}$ is consistent for $\theta$ if $\hat{\theta} \xrightarrow{p} \theta$ |  |
-| Theorem 6.3 multivariate Lindeberg-Lévy CLT | If $Y_i \in \mathbb{R}^k$ are i.i.d. and $\mathbb{E}\|Y\|^2 < \infty$, then $\sqrt{n}(\bar{Y} - \mu) \xrightarrow{d} N(0,V)$ where $\mu = \mathbb{E}[Y]$ and $V = \mathbb{E}[(Y-\mu)(Y-\mu)']$ |  |
-| Theorem 6.4 multivariate Lindeberg CLT | If $Y_{ni}$ are independent with $\mathbb{E}[Y_{ni}] = 0$, variance matrices $V_{ni}$, $\nu_n^2 = \lambda_{\min}(V_n) > 0$, and the Lindeberg condition $\nu_n^{-2} \sum_i \mathbb{E}[\|Y_{ni}\|^2 1\{\|Y_{ni}\|^2 \ge \epsilon \nu_n^2\}] \to 0$, then $V_n^{-1/2} \sum_i Y_{ni} \xrightarrow{d} N(0,I_k)$ |  |
-| Theorem 6.5 heterogeneous-array CLT | If $Y_{ni}$ are independent with $\mathbb{E}[Y_{ni}] = 0$, $n^{-1}\sum_i V_{ni} \to V > 0$, and $\sup_{n,i} \mathbb{E}\|Y_{ni}\|^{2+\delta} < \infty$ for some $\delta > 0$, then $\sqrt{n}\,\bar{Y} \xrightarrow{d} N(0,V)$ |  |
-| Theorem 6.6 Continuous Mapping Theorem in probability | If $Z_n \xrightarrow{p} c$ and $g$ is continuous at $c$, then $g(Z_n) \xrightarrow{p} g(c)$ |  |
+| Theorem 6.3 multivariate Lindeberg-Lévy CLT | If $Y_i \in \mathbb{R}^k$ are i.i.d. and $\mathbb{E}\lVert Y \rVert^2 < \infty$, then $\sqrt{n}(\bar{Y} - \mu) \xrightarrow{d} N(0,V)$ where $\mu = \mathbb{E}[Y]$ and $V = \mathbb{E}[(Y-\mu)(Y-\mu)']$ |  |
+| Theorem 6.4 multivariate Lindeberg CLT | If $Y_{ni}$ are independent with $\mathbb{E}[Y_{ni}] = 0$, variance matrices $V_{ni}$, $\nu_n^2 = \lambda_{\min}(V_n) > 0$, and the Lindeberg condition $\nu_n^{-2} \sum_i \mathbb{E}[\lVert Y_{ni} \rVert^2 1\{\lVert Y_{ni} \rVert^2 \ge \epsilon \nu_n^2\}] \to 0$, then $V_n^{-1/2} \sum_i Y_{ni} \xrightarrow{d} N(0,I_k)$ |  |
+| Theorem 6.5 heterogeneous-array CLT | If $Y_{ni}$ are independent with $\mathbb{E}[Y_{ni}] = 0$, $n^{-1}\sum_i V_{ni} \to V > 0$, and $\sup_{n,i} \mathbb{E}\lVert Y_{ni} \rVert^{2+\delta} < \infty$ for some $\delta > 0$, then $\sqrt{n}\,\bar{Y} \xrightarrow{d} N(0,V)$ |  |
+| Theorem 6.6 Continuous Mapping Theorem in probability | If $Z_n \xrightarrow{p} c$ and $g$ is continuous at $c$, then $g(Z_n) \xrightarrow{p} g(c)$ | [tendstoInMeasure_continuous_comp](../HansenEconometrics/AsymptoticUtils.lean#L47) — global CMT in probability; structured corollaries include [tendstoInMeasure_pi](../HansenEconometrics/AsymptoticUtils.lean#L104), [tendstoInMeasure_matrix_inv](../HansenEconometrics/AsymptoticUtils.lean#L223), [tendstoInMeasure_prodMk](../HansenEconometrics/AsymptoticUtils.lean#L252), [tendstoInMeasure_add](../HansenEconometrics/AsymptoticUtils.lean#L284), [tendstoInMeasure_mulVec](../HansenEconometrics/AsymptoticUtils.lean#L304), and [tendstoInMeasure_matrix_mul](../HansenEconometrics/AsymptoticUtils.lean#L325). |
 | Theorem 6.7 Continuous Mapping Theorem in distribution | If $Z_n \xrightarrow{d} Z$ and $g$ is continuous $Z$-a.s., then $g(Z_n) \xrightarrow{d} g(Z)$ |  |
 | Theorem 6.8 Delta Method | If $p_n(\hat{\mu} - \mu) \xrightarrow{d} \xi$ and $g$ is continuously differentiable near $\mu$, then $p_n(g(\hat{\mu}) - g(\mu)) \xrightarrow{d} G' \xi$ where $G = \partial g(\mu)'/\partial u$ |  |
-| Theorem 6.9 smooth-function consistency | If $Y_i \in \mathbb{R}^m$ are i.i.d., $h : \mathbb{R}^m \to \mathbb{R}^k$, $\mathbb{E}\|h(Y)\| < \infty$, and $g : \mathbb{R}^k \to \mathbb{R}^q$ is continuous at $\mu$, then $\hat{\theta} \xrightarrow{p} \theta$ |  |
-| Theorem 6.10 smooth-function asymptotic normality | If $Y_i \in \mathbb{R}^m$ are i.i.d., $\mathbb{E}\|h(Y)\|^2 < \infty$, and $g$ is continuously differentiable near $\mu$, then $\sqrt{n}(\hat{\theta} - \theta) \xrightarrow{d} N(0,V_\theta)$ where $V_\theta = G' V G$ |  |
-| Theorem 6.11 best unbiased estimation of the mean | If $\tilde{\mu}$ is unbiased for $\mu = \mathbb{E}[h(Y)]$ and $\mathbb{E}\|h(Y)\|^2 < \infty$, then $\operatorname{Var}(\tilde{\mu}) \ge n^{-1} V$ where $V = \mathbb{E}[(h(Y)-\mu)(h(Y)-\mu)']$ |  |
-| Theorem 6.12 moment bound implies stochastic boundedness | If $\mathbb{E}\|Z_n\|^\delta = O(a_n)$ for some $\delta > 0$, then $Z_n = O_p(a_n^{1/\delta})$; if $\mathbb{E}\|Z_n\|^\delta = o(a_n)$, then $Z_n = o_p(a_n^{1/\delta})$ |  |
-| Theorem 6.13 bounded first moments pass to the limit | If $Z_n \xrightarrow{d} Z$ and $\mathbb{E}\|Z_n\| \le C$, then $\mathbb{E}\|Z\| \le C$ |  |
-| Definition 6.4 uniform integrability | $Z_n$ is uniformly integrable if $\lim_{M \to \infty} \limsup_{n \to \infty} \mathbb{E}[\|Z_n\| 1\{\|Z_n\| > M\}] = 0$ |  |
-| Theorem 6.14 primitive condition for uniform integrability | If for some $\delta > 0$, $\mathbb{E}\|Z_n\|^{1+\delta} \le C < \infty$, then $Z_n$ is uniformly integrable |  |
+| Theorem 6.9 smooth-function consistency | If $Y_i \in \mathbb{R}^m$ are i.i.d., $h : \mathbb{R}^m \to \mathbb{R}^k$, $\mathbb{E}\lVert h(Y) \rVert < \infty$, and $g : \mathbb{R}^k \to \mathbb{R}^q$ is continuous at $\mu$, then $\hat{\theta} \xrightarrow{p} \theta$ |  |
+| Theorem 6.10 smooth-function asymptotic normality | If $Y_i \in \mathbb{R}^m$ are i.i.d., $\mathbb{E}\lVert h(Y) \rVert^2 < \infty$, and $g$ is continuously differentiable near $\mu$, then $\sqrt{n}(\hat{\theta} - \theta) \xrightarrow{d} N(0,V_\theta)$ where $V_\theta = G' V G$ |  |
+| Theorem 6.11 best unbiased estimation of the mean | If $\tilde{\mu}$ is unbiased for $\mu = \mathbb{E}[h(Y)]$ and $\mathbb{E}\lVert h(Y) \rVert^2 < \infty$, then $\operatorname{Var}(\tilde{\mu}) \ge n^{-1} V$ where $V = \mathbb{E}[(h(Y)-\mu)(h(Y)-\mu)']$ |  |
+| Theorem 6.12 moment bound implies stochastic boundedness | If $\mathbb{E}\lVert Z_n \rVert^\delta = O(a_n)$ for some $\delta > 0$, then $Z_n = O_p(a_n^{1/\delta})$; if $\mathbb{E}\lVert Z_n \rVert^\delta = o(a_n)$, then $Z_n = o_p(a_n^{1/\delta})$ | [BoundedInProbability](../HansenEconometrics/AsymptoticUtils.lean#L667) definition plus [BoundedInProbability.of_tendstoInDistribution](../HansenEconometrics/AsymptoticUtils.lean#L675), [BoundedInProbability.of_tendstoInMeasure_const](../HansenEconometrics/AsymptoticUtils.lean#L727), [BoundedInProbability.of_abs_le](../HansenEconometrics/AsymptoticUtils.lean#L748), [BoundedInProbability.add](../HansenEconometrics/AsymptoticUtils.lean#L764), and Slutsky-style [TendstoInMeasure.mul_boundedInProbability](../HansenEconometrics/AsymptoticUtils.lean#L835). |
+| Theorem 6.13 bounded first moments pass to the limit | If $Z_n \xrightarrow{d} Z$ and $\mathbb{E}\lVert Z_n \rVert \le C$, then $\mathbb{E}\lVert Z \rVert \le C$ |  |
+| Definition 6.4 uniform integrability | $Z_n$ is uniformly integrable if $\lim_{M \to \infty} \limsup_{n \to \infty} \mathbb{E}[\lVert Z_n \rVert 1\{\lVert Z_n \rVert > M\}] = 0$ |  |
+| Theorem 6.14 primitive condition for uniform integrability | If for some $\delta > 0$, $\mathbb{E}\lVert Z_n \rVert^{1+\delta} \le C < \infty$, then $Z_n$ is uniformly integrable |  |
 | Theorem 6.15 convergence of moments under uniform integrability | If $Z_n \xrightarrow{d} Z$ and $Z_n$ is uniformly integrable, then $\mathbb{E}[Z_n] \to \mathbb{E}[Z]$ |  |
-| Theorem 6.16 uniform stochastic bounds for maxima | If $|Y_i|^r$ is uniformly integrable, then $n^{-1/r} \max_{1 \le i \le n} |Y_i| \xrightarrow{p} 0$ |  |
+| Theorem 6.16 uniform stochastic bounds for maxima | If $\lvert Y_i \rvert^r$ is uniformly integrable, then $n^{-1/r} \max_{1 \le i \le n} \lvert Y_i \rvert \xrightarrow{p} 0$ |  |
+
+## Lean-only bridge results
+
+These reusable Lean bridges support Chapter 6 and later asymptotic chapters, but do not have a one-to-one Hansen textbook statement in the crosswalk above.
+
+- [cramerWold_tendstoInDistribution](../HansenEconometrics/AsymptoticUtils.lean#L160) — Cramér–Wold device for `TendstoInDistribution` over an inner-product space, used to lift Mathlib's one-dimensional CLT to multivariate CLTs.
+- [tendstoInMeasure_continuousAt_const_comp](../HansenEconometrics/AsymptoticUtils.lean#L70) — CMT-at-a-point specialization, allowing pointwise rather than global continuity.
+- [tendstoInMeasure_pi](../HansenEconometrics/AsymptoticUtils.lean#L104) — coordinatewise convergence implies joint convergence over a finite-dimensional product, independently useful as matrix-CMT scaffolding.
+- Structured CMT corollaries: [tendstoInMeasure_matrix_inv](../HansenEconometrics/AsymptoticUtils.lean#L223), [tendstoInMeasure_matrix_mul](../HansenEconometrics/AsymptoticUtils.lean#L325), [tendstoInMeasure_mulVec](../HansenEconometrics/AsymptoticUtils.lean#L304), [tendstoInMeasure_add](../HansenEconometrics/AsymptoticUtils.lean#L284), and [tendstoInMeasure_prodMk](../HansenEconometrics/AsymptoticUtils.lean#L252).
+- `BoundedInProbability` family: [BoundedInProbability.of_tendstoInDistribution](../HansenEconometrics/AsymptoticUtils.lean#L675), [BoundedInProbability.of_tendstoInMeasure_const](../HansenEconometrics/AsymptoticUtils.lean#L727), [BoundedInProbability.of_abs_le](../HansenEconometrics/AsymptoticUtils.lean#L748), and [BoundedInProbability.add](../HansenEconometrics/AsymptoticUtils.lean#L764).
+- [TendstoInMeasure.mul_boundedInProbability](../HansenEconometrics/AsymptoticUtils.lean#L835) — Slutsky-style “small times bounded is small” lemma feeding Chapter 7 noise terms.
+- [TendstoInDistribution.tendsto_measure_preimage_of_null_frontier_real](../HansenEconometrics/AsymptoticUtils.lean#L802) — Portmanteau direction used as the working CMT-in-distribution face.
 
 ## Notes
 
-- Chapter 6 is not yet formalized in Lean in this repo, so this crosswalk is intentionally textbook-
-  side only for now.
+- The Chapter 6 results that Chapter 7 actually consumes — WLLN, CLT, Cramér–Wold, CMT in probability, `O_p`/`o_p`, and Slutsky — are backed by Mathlib plus `HansenEconometrics/AsymptoticUtils.lean`.
+- **Compositional / definitional blanks:** Theorem 6.2 is obtained as the composition of `tendstoInMeasure_wlln` and `tendstoInMeasure_continuous_comp`. Definition 6.3 (consistency) is the Mathlib idiom `TendstoInMeasure μ X atTop (fun _ => θ)` used directly throughout `AsymptoticUtils.lean` and Chapter 7; no standalone `Consistent` definition is added.
+- **CLT path blank:** Theorem 6.3 (multivariate Lindeberg–Lévy CLT) does not have a Hansen-shaped wrapper in the repo. The Chapter 7 vector CLT path consumes Mathlib's i.i.d. one-dimensional CLT (`ProbabilityTheory.tendstoInDistribution_inv_sqrt_mul_sum_sub`) composed with the local `cramerWold_tendstoInDistribution` bridge (see Lean-only bridge results above).
+- **CMT-in-distribution blank:** Theorem 6.7 has no Hansen-shaped wrapper. The Portmanteau-direction theorem `TendstoInDistribution.tendsto_measure_preimage_of_null_frontier_real` is the working face used by Chapter 7 (see Lean-only bridge results above).
+- **Outstanding work, tracked:** Theorems 6.8, 6.9, 6.10, 6.11, 6.13, Definition 6.4 / Theorems 6.14 / 6.15 (UI layer), and Theorem 6.16 are genuinely outstanding and tracked in [#41](https://github.com/mostlyharmfuleconometrics/lean-hansen-econometrics/issues/41).
+- **Outstanding work, not tracked:** Theorems 6.4 (multivariate Lindeberg CLT) and 6.5 (heterogeneous-array CLT) are not yet formalized and are **not** tracked there.


### PR DESCRIPTION
Closes #32.

## Summary

Collapse the two parallel ~50-line HC2/HC3 leverage-adjustment-weight-norm convergence proofs in `Chapter7Asymptotics/MiddleConsistency.lean` into a single generic linear-bound backend.

**Net: -51 lines** in `MiddleConsistency.lean` (907, was 958). `lake build` is green.

## Changes

- Add `private` generic lemma `levAdjWtNormStar_le_of_linearBound`: given any weight satisfying `|w(h) - 1| ≤ C · h` on `[0, 1/2]` with `0 ≤ C`, and any `0 ≤ δ ≤ 1/2` with `maxLeverageStar X < δ`, conclude `levAdjWtNormStar weight X ≤ C · δ`.
- Add `private` generic convergence lemma `levAdjWtNormStar_tendstoInMeasure_zero_of_linearBound`: same shape but upgrades `oₚ(1)` for max leverage to `oₚ(1)` for the weight norm. The `δ = min (1/4) (ε/(2·C))` construction needs `0 < C`.
- Delete file-local helpers `levAdjWtNormStar_hc{2,3}_lt_maxLevStar_lt`. Their only consumers were the convergence theorems also being rewritten.
- Rewrite `levAdjWtNormStar_hc{2,3}_tendstoInMeasure_zero_maxLevStar` as 3-line specializations over the generic backend. **Public signatures unchanged.**
- `hc{2,3}Weight_abs_sub_one_le_*_mul` kept untouched as the per-family bound inputs.

## Visibility

| Symbol | Before | After |
|---|---|---|
| `hc{2,3}Weight_abs_sub_one_le_*_mul` | public | public (unchanged) |
| `levAdjWtNormStar_hc{2,3}_lt_maxLevStar_lt` | public | **deleted** |
| `levAdjWtNormStar_hc{2,3}_tendstoInMeasure_zero_maxLevStar` | public | public (one-liner over generic) |
| `levAdjWtNormStar_le_of_linearBound` | n/a | `private` (new) |
| `levAdjWtNormStar_tendstoInMeasure_zero_of_linearBound` | n/a | `private` (new) |

## Why this is smaller than the original issue proposal

Issue #32 originally proposed a `RobustWeightScheme` structure unifying HC0/HC1/HC2/HC3 with an estimated ~600-line saving. Scouting the actual code surfaced four reasons that proposal would not pull its weight:

1. **The `weight : ℝ → ℝ` parameterization already exists** at the `sampleScoreCovLevAdjStar` / `olsHetCovLevAdjStar` layer in `SampleMiddle.lean` and `SandwichAssembly.lean`. HC2 and HC3 are already one-line `simpa` specializations of it. A `RobustWeightScheme` structure would mostly relocate existing generic code.
2. **HC1 is architecturally outside the weight-function shape**: `olsHetCovHC1Star = (n / (n - k)) • olsHetCovStar` is a scalar multiple of the HC0 sandwich, not built on `olsHetCovLevAdjStar` at all. Folding it in requires a richer two-component scheme and re-architecting its proof — more work than the savings justify.
3. **Bound-domain mismatch**: the issue's proposed `Set.Ico 0 1` is too weak for the existing constants `2` and `8`, which only hold on `[0, 1/2]` (`hc2Weight_abs_sub_one_le_two_mul`, `hc3Weight_abs_sub_one_le_eight_mul`).
4. **Three named declarations cited in the issue body do not exist** with those names (`sampleScoreCovHC0Star`, `sampleScoreCovHC1Star`, `olsHetCovHC0Star`); HC0's middle and sandwich are `sampleScoreCovStar` / `olsHetCovStar`, and HC1 has no separate middle matrix.

Realistic ceiling for the structure-as-proposed (HC0/HC2/HC3 only): ~100–150 net lines saved with ~80 lines of new structure boilerplate. This PR captures the only piece of real duplication — the parallel HC2/HC3 weight-norm convergence proofs — without introducing a structure that would mostly relocate code.

If/when an HC4 or other linear-bound variant lands in `MiddleConsistency.lean`, the new `private` backend is the natural home for it; drop the `private` markers at that time.

## Verification

- `lake build`: green (3127 jobs).
- Public API: HC2/HC3 convergence wrapper signatures byte-identical to originals; consumers in `Normality.lean` and `Inference.lean` unaffected.
- No imports added or removed.
- Pre-existing `simp` flexibility warnings at the `sampleScoreCovStar` algebra are not introduced by this PR (verified by stash-and-rebuild).

## Process

- Scout: `/tmp/forge/issue-32/scout.md`
- Plan + plan-review consensus: `/tmp/forge/issue-32/plan.md`, `/tmp/forge/issue-32/plan-review/consensus.md`
- Code-review consensus (unanimous LGTM, round 1): `/tmp/forge/issue-32/code-review/consensus.md`
