### PR TITLE
Add Hansen Theorem 3.1 uniqueness half: OLS is the unique SSE minimizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ site/_generated/
 .agents/
 .pi/
 
+.plans/
+.claude/
+.workflow/

--- a/HansenEconometrics/Chapter3LeastSquaresAlgebra.lean
+++ b/HansenEconometrics/Chapter3LeastSquaresAlgebra.lean
@@ -164,4 +164,18 @@ theorem olsBeta_isMinOn
   intro b _
   exact sumSquaredErrors_olsBeta_le X y b
 
+/-- Hansen Theorem 3.1 (uniqueness half): if `b` attains the minimum of the SSE, then
+`b = olsBeta X y`. Combined with `sumSquaredErrors_olsBeta_le` and `olsBeta_isMinOn`,
+this completes Hansen's Theorem 3.1: `olsBeta X y` is the unique minimizer of
+`sumSquaredErrors X y` over `k → ℝ` whenever `Xᵀ * X` is invertible. -/
+theorem olsBeta_eq_of_minimizer
+    (X : Matrix n k ℝ) (y : n → ℝ) (b : k → ℝ) [Invertible (Xᵀ * X)]
+    (hb : sumSquaredErrors X y b = sumSquaredErrors X y (olsBeta X y)) :
+    b = olsBeta X y := by
+  rw [sumSquaredErrors_eq_linearProjectionMSE X y b,
+      sumSquaredErrors_eq_linearProjectionMSE X y (olsBeta X y)] at hb
+  exact linearProjectionBeta_eq_of_MSE_eq
+    (Xᵀ * X) (Xᵀ *ᵥ y) (y ⬝ᵥ y) b
+    (gram_transpose X) (fun v hv => gram_quadratic_pos X hv) hb
+
 end HansenEconometrics

--- a/HansenEconometrics/LinearAlgebraUtils.lean
+++ b/HansenEconometrics/LinearAlgebraUtils.lean
@@ -114,6 +114,29 @@ lemma gram_quadratic_nonneg {n k : Type*} [Fintype n] [Fintype k]
       vecMul_eq_mulVec_transpose, Matrix.transpose_transpose]
   exact dotProduct_star_self_nonneg (X *ᵥ v)
 
+/-- Strict positive-definiteness of the Gram matrix under invertibility: for any
+`v ≠ 0`, `0 < v ⬝ᵥ ((Xᵀ * X) *ᵥ v)`. Strengthens `gram_quadratic_nonneg` whenever
+`Xᵀ * X` is invertible. Used to discharge the strict-positivity hypothesis of Chapter 2's
+`linearProjectionBeta_eq_of_MSE_eq` when specialized to sample moments. -/
+lemma gram_quadratic_pos {n k : Type*} [Fintype n] [Fintype k] [DecidableEq k]
+    (X : Matrix n k ℝ) [Invertible (Xᵀ * X)] {v : k → ℝ} (hv : v ≠ 0) :
+    0 < v ⬝ᵥ ((Xᵀ * X) *ᵥ v) := by
+  rcases (gram_quadratic_nonneg X v).lt_or_eq with h | h
+  · exact h
+  · exfalso
+    have hquad : v ⬝ᵥ ((Xᵀ * X) *ᵥ v) = (X *ᵥ v) ⬝ᵥ (X *ᵥ v) := by
+      rw [← Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec,
+          vecMul_eq_mulVec_transpose, Matrix.transpose_transpose]
+    rw [hquad] at h
+    have hXv : X *ᵥ v = 0 := dotProduct_self_eq_zero.mp h.symm
+    have hXtXv : (Xᵀ * X) *ᵥ v = 0 := by
+      rw [← Matrix.mulVec_mulVec, hXv, Matrix.mulVec_zero]
+    have hv0 : v = 0 := by
+      have h1 : ⅟ (Xᵀ * X) *ᵥ ((Xᵀ * X) *ᵥ v) = 0 := by
+        rw [hXtXv, Matrix.mulVec_zero]
+      rwa [Matrix.mulVec_mulVec, invOf_mul_self, Matrix.one_mulVec] at h1
+    exact hv hv0
+
 /-- Eigenvalues of a real Hermitian idempotent matrix are `0` or `1`. -/
 theorem eigenvalues_zero_or_one_of_isHermitian_idempotent {n : Type*} [Fintype n] [DecidableEq n]
     {A : Matrix n n ℝ}

--- a/inventory/ch3-inventory.md
+++ b/inventory/ch3-inventory.md
@@ -57,8 +57,8 @@ Theorem 3.5 coefficient and residual equivalence now landed. Theorem 3.4 partiti
 coefficient formulae are still pending.
 
 ## Immediate target
-Backfill Theorem 3.4 partitioned coefficient formulae or the objective-level Theorem 3.1 argmin
-statement, then continue forward to leverage and leave-one-out results.
+Backfill Theorem 3.4 partitioned coefficient formulae, then continue forward to leverage and
+leave-one-out results.
 
 ## Source text
 - `textbook/ch03/ch3_excerpt.txt` is a text extract of `chapters/03-the-algebra-of-least-squares.pdf`,
@@ -128,8 +128,9 @@ not surfaced here.
 ## Notes
 
 - Theorem 3.4 is still intentionally blank: it is one of the main remaining Chapter 3
-  theorem labels not yet wrapped in the current Lean layer. Theorem 3.1 has its existence
-  half landed; uniqueness is still pending.
+  theorem labels not yet wrapped in the current Lean layer. Theorem 3.1 is fully landed
+  (existence half via `sumSquaredErrors_olsBeta_le` / `olsBeta_isMinOn`; uniqueness via
+  `olsBeta_eq_of_minimizer`).
 - Several Lean helper results in the projection file are stronger than the textbook labels because
   they package reusable matrix facts such as rank and Hermitian structure.
 - The projection-rank helper [rank_hatMatrix](../../HansenEconometrics/Chapter3Projections.lean#L174)

--- a/inventory/ch3-inventory.md
+++ b/inventory/ch3-inventory.md
@@ -18,9 +18,9 @@ Status:
 - Definition 3.1 SSE notation and the `β̂` residual-sum-of-squares specialization landed.
 - Equation (3.17), residuals summing to zero when a constant is in the column span, landed.
 - normal-equation uniqueness for the closed-form OLS coefficient landed.
-- Theorem 3.1 existence half (β̂ attains the minimum) landed via `sumSquaredErrors_olsBeta_le`
-  and `olsBeta_isMinOn`. Uniqueness (any minimizer equals β̂) is still pending, mirroring
-  `linearProjectionBeta_eq_of_MSE_eq` in Chapter 2.
+- Theorem 3.1 (β̂ is the unique minimizer of SSE) fully landed via
+  `sumSquaredErrors_olsBeta_le`, `olsBeta_isMinOn`, and `olsBeta_eq_of_minimizer`.
+  The bridge `sumSquaredErrors_eq_linearProjectionMSE` is private to the file.
 
 ### Layer 2: projection matrices
 7. define hat matrix `P = X (Xᵀ X)⁻¹ Xᵀ`
@@ -94,7 +94,7 @@ Conventions:
 
 | Textbook result | LaTeX | Lean theorem |
 | --- | --- | --- |
-| Theorem 3.1 objective-level argmin statement (existence half) | $\hat{\beta} = \arg\min_b (Y - X b)'(Y - X b)$ | [sumSquaredErrors_olsBeta_le](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L150)<br>`sumSquaredErrors X y (olsBeta X y) ≤ sumSquaredErrors X y b`<br>[olsBeta_isMinOn](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L161)<br>`IsMinOn (sumSquaredErrors X y) Set.univ (olsBeta X y)` |
+| Theorem 3.1 objective-level argmin statement | $\hat{\beta} = \arg\min_b (Y - X b)'(Y - X b)$ | [sumSquaredErrors_olsBeta_le](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L150)<br>`sumSquaredErrors X y (olsBeta X y) ≤ sumSquaredErrors X y b`<br>[olsBeta_isMinOn](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L161)<br>`IsMinOn (sumSquaredErrors X y) Set.univ (olsBeta X y)`<br>[olsBeta_eq_of_minimizer](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L171)<br>`SSE(b) = SSE(olsBeta X y) → b = olsBeta X y` |
 | Definition 3.1 sum of squared errors | $S(b) = (Y - X b)'(Y - X b)$ | [sumSquaredErrors](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L16)<br><code>sumSquaredErrors X y b := (y - X *ᵥ b) ⬝ᵥ (y - X *ᵥ b)</code> |
 | Theorem 3.2 closed-form OLS coefficient | $\hat{\beta} = (X'X)^{-1} X' Y$ | [olsBeta](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L20)<br><code>olsBeta X y := (⅟ (Xᵀ * X)) *ᵥ (Xᵀ *ᵥ y)</code> |
 | Theorem 3.2 normal equations | $X' \hat{e} = 0$ | [normal_equations](../../HansenEconometrics/Chapter3LeastSquaresAlgebra.lean#L32)<br><code>Xᵀ *ᵥ residual X y = 0</code> |
@@ -117,6 +117,7 @@ Conventions:
 | Lean theorem | Role |
 | --- | --- |
 | [gram_quadratic_nonneg](../../HansenEconometrics/LinearAlgebraUtils.lean#L110) | `0 ≤ v ⬝ᵥ ((Xᵀ * X) *ᵥ v)` for all `v`; the Gram matrix is positive semidefinite |
+| [gram_quadratic_pos](../../HansenEconometrics/LinearAlgebraUtils.lean#L121) | `0 < v ⬝ᵥ ((Xᵀ * X) *ᵥ v)` for any `v ≠ 0` under `[Invertible (Xᵀ * X)]`; the strict-positive-definiteness companion of `gram_quadratic_nonneg`, used to discharge the uniqueness hypothesis of Hansen Theorem 3.1 |
 | [gram_transpose](../../HansenEconometrics/LinearAlgebraUtils.lean#L51) | `(Xᵀ * X)ᵀ = Xᵀ * X` (relocated from `Chapter3Projections.lean` to break a potential circular import) |
 | [inv_gram_transpose](../../HansenEconometrics/LinearAlgebraUtils.lean#L60) | `(⅟ (Xᵀ * X))ᵀ = ⅟ (Xᵀ * X)` (relocated from `Chapter3Projections.lean` alongside `gram_transpose`; cited from Ch 3–5) |
 


### PR DESCRIPTION
## Summary

Completes Hansen's Theorem 3.1. Existence half (`SSE(olsBeta X y) ≤ SSE(b)` for every `b`) landed in #33; this PR proves the matching uniqueness half: under `[Invertible (Xᵀ * X)]`, any `b` that attains the minimum equals `olsBeta X y`.

The proof routes through Chapter 2's existing `linearProjectionBeta_eq_of_MSE_eq`, the same way the existence half routed through `linearProjectionBeta_minimizes_MSE`. With `gram_transpose` and the new `gram_quadratic_pos` discharging the symmetry and strict-positive-definiteness hypotheses, and the file-private bridge lemma converting between SSE and `linearProjectionMSE`, the proof is five lines.

## What's added

In `HansenEconometrics/LinearAlgebraUtils.lean`:

- `gram_quadratic_pos` — strict positive-definiteness of `Xᵀ * X` under invertibility. For any `v ≠ 0`, `0 < v ⬝ᵥ ((Xᵀ * X) *ᵥ v)`. The strict-inequality companion to the existing `gram_quadratic_nonneg`.

In `HansenEconometrics/Chapter3LeastSquaresAlgebra.lean`:

- `olsBeta_eq_of_minimizer` — Hansen Theorem 3.1 uniqueness half: `SSE(b) = SSE(olsBeta X y) → b = olsBeta X y`.

In `inventory/ch3-inventory.md`:

- The Theorem 3.1 row in the main Crosswalk table loses the "(existence half)" qualifier and gains the new theorem as a third linked Lean entry.
- The chapter-3 status bullet about Theorem 3.1 is rewritten to record full Theorem 3.1 as landed.
- The "Lean-only bridge results" subsection gains a row for `gram_quadratic_pos` alongside `gram_quadratic_nonneg`, for consistency with the existing precedent.

## Verification

- `lake build` exits 0 with `Build completed successfully (3127 jobs)`.
- The two modified Lean files compile clean (✔ status, no linter warnings on the new declarations).