### PR TITLE
Add Hansen Theorem 3.4: partitioned coefficient formulae

### DIFF
--- a/HansenEconometrics/Chapter3FWL.lean
+++ b/HansenEconometrics/Chapter3FWL.lean
@@ -158,6 +158,163 @@ theorem fromColsRightBeta_eq_fwlBeta
     (fromColsRightBeta X₁ X₂ y)
     (fwl_fromColsRightBeta_normal_equations X₁ X₂ y)
 
+/-- Mirror of `fwl_auxiliary_residual_eq_annihilator_full_residual` for the left
+block: the auxiliary residual `M₂Y - (M₂X₁) ⋅ β̂₁` equals `M₂` applied to the
+full-regression residual. Companion to the existing right-block version, used in the
+proof of the symmetric Theorem 3.5 coefficient identity for β̂₁. -/
+theorem fwl_auxiliary_residual_eq_annihilator_full_residual_left
+    (X₁ : Matrix n k₁ ℝ) (X₂ : Matrix n k₂ ℝ) (y : n → ℝ)
+    [DecidableEq n] [Fintype k₁] [DecidableEq k₁] [Fintype k₂] [DecidableEq k₂]
+    [Invertible (X₂ᵀ * X₂)]
+    [Invertible ((Matrix.fromCols X₁ X₂)ᵀ * Matrix.fromCols X₁ X₂)] :
+    annihilatorMatrix X₂ *ᵥ y -
+        residualizedRegressors X₂ X₁ *ᵥ fromColsLeftBeta X₁ X₂ y =
+      annihilatorMatrix X₂ *ᵥ residual (Matrix.fromCols X₁ X₂) y := by
+  unfold residual fitted residualizedRegressors
+  rw [fromCols_full_fitted_eq]
+  rw [Matrix.mulVec_sub, Matrix.mulVec_add]
+  rw [Matrix.mulVec_mulVec (fromColsRightBeta X₁ X₂ y) (annihilatorMatrix X₂) X₂]
+  rw [annihilator_mul_X]
+  ext i
+  simp [sub_eq_add_neg]
+
+/-- Mirror of `fwl_fromColsRightBeta_normal_equations`: the full-regression left block
+satisfies the symmetric FWL auxiliary normal equations (with M₂ as the residual maker). -/
+theorem fwl_fromColsLeftBeta_normal_equations
+    (X₁ : Matrix n k₁ ℝ) (X₂ : Matrix n k₂ ℝ) (y : n → ℝ)
+    [DecidableEq n] [Fintype k₁] [DecidableEq k₁] [Fintype k₂] [DecidableEq k₂]
+    [Invertible (X₂ᵀ * X₂)]
+    [Invertible ((Matrix.fromCols X₁ X₂)ᵀ * Matrix.fromCols X₁ X₂)] :
+    (residualizedRegressors X₂ X₁)ᵀ *ᵥ
+        (annihilatorMatrix X₂ *ᵥ y -
+          residualizedRegressors X₂ X₁ *ᵥ fromColsLeftBeta X₁ X₂ y) = 0 := by
+  rw [fwl_auxiliary_residual_eq_annihilator_full_residual_left]
+  have hM :
+      annihilatorMatrix X₂ *ᵥ residual (Matrix.fromCols X₁ X₂) y =
+        residual (Matrix.fromCols X₁ X₂) y :=
+    annihilator_mulVec_eq_self_of_regressors_orthogonal X₂
+      (residual (Matrix.fromCols X₁ X₂) y)
+      (normal_equations_fromCols_right X₁ X₂ y)
+  rw [hM]
+  unfold residualizedRegressors
+  rw [Matrix.transpose_mul, annihilatorMatrix_transpose]
+  rw [← Matrix.mulVec_mulVec (residual (Matrix.fromCols X₁ X₂) y) X₁ᵀ
+    (annihilatorMatrix X₂)]
+  rw [hM]
+  exact normal_equations_fromCols_left X₁ X₂ y
+
+/-- Symmetric companion to `fromColsRightBeta_eq_fwlBeta`: the left block of the full
+regression equals the FWL coefficient computed by partialling out X₂. The two together
+say:
+
+  fromColsRightBeta X₁ X₂ y = fwlBeta X₁ X₂ y    -- X₁ residualizes X₂ (right block)
+  fromColsLeftBeta  X₁ X₂ y = fwlBeta X₂ X₁ y    -- X₂ residualizes X₁ (left block)
+-/
+theorem fromColsLeftBeta_eq_fwlBeta
+    (X₁ : Matrix n k₁ ℝ) (X₂ : Matrix n k₂ ℝ) (y : n → ℝ)
+    [DecidableEq n] [Fintype k₁] [DecidableEq k₁] [Fintype k₂] [DecidableEq k₂]
+    [Invertible (X₂ᵀ * X₂)]
+    [Invertible ((Matrix.fromCols X₁ X₂)ᵀ * Matrix.fromCols X₁ X₂)]
+    [Invertible ((residualizedRegressors X₂ X₁)ᵀ * residualizedRegressors X₂ X₁)] :
+    fromColsLeftBeta X₁ X₂ y = fwlBeta X₂ X₁ y := by
+  symm
+  unfold fwlBeta
+  exact olsBeta_eq_of_normal_equations
+    (residualizedRegressors X₂ X₁)
+    (annihilatorMatrix X₂ *ᵥ y)
+    (fromColsLeftBeta X₁ X₂ y)
+    (fwl_fromColsLeftBeta_normal_equations X₁ X₂ y)
+
+/-- Hansen Theorem 3.4, equation (3.38): the right block of the partitioned-regression
+OLS coefficient has the explicit form `(X₂' M₁ X₂)⁻¹ (X₂' M₁ Y)`. Combined with
+`fromColsLeftBeta_eq_partitioned_form` (Eq. 3.37), this gives both halves of Hansen
+Theorem 3.4. -/
+theorem fromColsRightBeta_eq_partitioned_form
+    (X₁ : Matrix n k₁ ℝ) (X₂ : Matrix n k₂ ℝ) (y : n → ℝ)
+    [DecidableEq n] [Fintype k₁] [DecidableEq k₁] [Fintype k₂] [DecidableEq k₂]
+    [Invertible (X₁ᵀ * X₁)]
+    [Invertible ((Matrix.fromCols X₁ X₂)ᵀ * Matrix.fromCols X₁ X₂)]
+    [Invertible (X₂ᵀ * annihilatorMatrix X₁ * X₂)] :
+    fromColsRightBeta X₁ X₂ y =
+      (⅟ (X₂ᵀ * annihilatorMatrix X₁ * X₂)) *ᵥ
+        (X₂ᵀ *ᵥ (annihilatorMatrix X₁ *ᵥ y)) := by
+  have hquad :
+      (residualizedRegressors X₁ X₂)ᵀ * residualizedRegressors X₁ X₂ =
+        X₂ᵀ * annihilatorMatrix X₁ * X₂ := by
+    unfold residualizedRegressors
+    rw [Matrix.transpose_mul, annihilatorMatrix_transpose, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (annihilatorMatrix X₁) (annihilatorMatrix X₁) X₂]
+    rw [show annihilatorMatrix X₁ * annihilatorMatrix X₁ = annihilatorMatrix X₁
+      from annihilatorMatrix_idempotent X₁]
+    rw [← Matrix.mul_assoc]
+  have hcross :
+      (residualizedRegressors X₁ X₂)ᵀ *ᵥ (annihilatorMatrix X₁ *ᵥ y) =
+        X₂ᵀ *ᵥ (annihilatorMatrix X₁ *ᵥ y) := by
+    unfold residualizedRegressors
+    rw [Matrix.transpose_mul, annihilatorMatrix_transpose]
+    rw [← Matrix.mulVec_mulVec]
+    have hidem :
+        annihilatorMatrix X₁ *ᵥ (annihilatorMatrix X₁ *ᵥ y) =
+          annihilatorMatrix X₁ *ᵥ y := by
+      rw [Matrix.mulVec_mulVec]
+      rw [show annihilatorMatrix X₁ * annihilatorMatrix X₁ = annihilatorMatrix X₁
+        from annihilatorMatrix_idempotent X₁]
+    rw [hidem]
+  have : Invertible ((residualizedRegressors X₁ X₂)ᵀ * residualizedRegressors X₁ X₂) :=
+    (inferInstance : Invertible (X₂ᵀ * annihilatorMatrix X₁ * X₂)).copy _ hquad
+  have hInvOfEq :
+      ⅟ ((residualizedRegressors X₁ X₂)ᵀ * residualizedRegressors X₁ X₂) =
+        ⅟ (X₂ᵀ * annihilatorMatrix X₁ * X₂) := by
+    rw [Matrix.invOf_eq_nonsing_inv, Matrix.invOf_eq_nonsing_inv, hquad]
+  rw [fromColsRightBeta_eq_fwlBeta]
+  unfold fwlBeta olsBeta
+  rw [hcross, hInvOfEq]
+
+/-- Hansen Theorem 3.4, equation (3.37): the left block of the partitioned-regression
+OLS coefficient has the explicit form `(X₁' M₂ X₁)⁻¹ (X₁' M₂ Y)`. Symmetric companion
+to `fromColsRightBeta_eq_partitioned_form` (Eq. 3.38); the two together give Hansen
+Theorem 3.4. -/
+theorem fromColsLeftBeta_eq_partitioned_form
+    (X₁ : Matrix n k₁ ℝ) (X₂ : Matrix n k₂ ℝ) (y : n → ℝ)
+    [DecidableEq n] [Fintype k₁] [DecidableEq k₁] [Fintype k₂] [DecidableEq k₂]
+    [Invertible (X₂ᵀ * X₂)]
+    [Invertible ((Matrix.fromCols X₁ X₂)ᵀ * Matrix.fromCols X₁ X₂)]
+    [Invertible (X₁ᵀ * annihilatorMatrix X₂ * X₁)] :
+    fromColsLeftBeta X₁ X₂ y =
+      (⅟ (X₁ᵀ * annihilatorMatrix X₂ * X₁)) *ᵥ
+        (X₁ᵀ *ᵥ (annihilatorMatrix X₂ *ᵥ y)) := by
+  have hquad :
+      (residualizedRegressors X₂ X₁)ᵀ * residualizedRegressors X₂ X₁ =
+        X₁ᵀ * annihilatorMatrix X₂ * X₁ := by
+    unfold residualizedRegressors
+    rw [Matrix.transpose_mul, annihilatorMatrix_transpose, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (annihilatorMatrix X₂) (annihilatorMatrix X₂) X₁]
+    rw [show annihilatorMatrix X₂ * annihilatorMatrix X₂ = annihilatorMatrix X₂
+      from annihilatorMatrix_idempotent X₂]
+    rw [← Matrix.mul_assoc]
+  have hcross :
+      (residualizedRegressors X₂ X₁)ᵀ *ᵥ (annihilatorMatrix X₂ *ᵥ y) =
+        X₁ᵀ *ᵥ (annihilatorMatrix X₂ *ᵥ y) := by
+    unfold residualizedRegressors
+    rw [Matrix.transpose_mul, annihilatorMatrix_transpose]
+    rw [← Matrix.mulVec_mulVec]
+    have hidem :
+        annihilatorMatrix X₂ *ᵥ (annihilatorMatrix X₂ *ᵥ y) =
+          annihilatorMatrix X₂ *ᵥ y := by
+      rw [Matrix.mulVec_mulVec]
+      rw [show annihilatorMatrix X₂ * annihilatorMatrix X₂ = annihilatorMatrix X₂
+        from annihilatorMatrix_idempotent X₂]
+    rw [hidem]
+  have : Invertible ((residualizedRegressors X₂ X₁)ᵀ * residualizedRegressors X₂ X₁) :=
+    (inferInstance : Invertible (X₁ᵀ * annihilatorMatrix X₂ * X₁)).copy _ hquad
+  have hInvOfEq :
+      ⅟ ((residualizedRegressors X₂ X₁)ᵀ * residualizedRegressors X₂ X₁) =
+        ⅟ (X₁ᵀ * annihilatorMatrix X₂ * X₁) := by
+    rw [Matrix.invOf_eq_nonsing_inv, Matrix.invOf_eq_nonsing_inv, hquad]
+  rw [fromColsLeftBeta_eq_fwlBeta]
+  unfold fwlBeta olsBeta
+  rw [hcross, hInvOfEq]
+
 /-- Hansen Theorem 3.5, residual part: FWL and full OLS produce the same residual. -/
 theorem fwl_residual_eq_full_residual
     (X₁ : Matrix n k₁ ℝ) (X₂ : Matrix n k₂ ℝ) (y : n → ℝ)

--- a/inventory/ch3-inventory.md
+++ b/inventory/ch3-inventory.md
@@ -53,12 +53,13 @@ The centered analysis-of-variance formula and `R²` identities are still pending
 Status: partitioned normal-equation projections, residualized regressors `M₁ X₂`, FWL residualized
 normal equations, and the sequential residual-maker result
 `M_{M₁X₂} M₁ [X₁ X₂] = 0` landed in `HansenEconometrics/Chapter3FWL.lean`.
-Theorem 3.5 coefficient and residual equivalence now landed. Theorem 3.4 partitioned
-coefficient formulae are still pending.
+Theorem 3.5 coefficient and residual equivalence landed. Theorem 3.4 partitioned coefficient
+formulae landed via `fromColsLeftBeta_eq_partitioned_form` (Eq. 3.37) and
+`fromColsRightBeta_eq_partitioned_form` (Eq. 3.38), with the supporting symmetric FWL identity
+`fromColsLeftBeta_eq_fwlBeta`.
 
 ## Immediate target
-Backfill Theorem 3.4 partitioned coefficient formulae, then continue forward to leverage and
-leave-one-out results.
+Continue forward to leverage and leave-one-out results (Sections 3.20–3.21).
 
 ## Source text
 - `textbook/ch03/ch3_excerpt.txt` is a text extract of `chapters/03-the-algebra-of-least-squares.pdf`,
@@ -108,8 +109,8 @@ Conventions:
 | Equation (3.23) residual representation | $\hat{e} = M Y$ | [residual_eq_annihilator_mul_y](../../HansenEconometrics/Chapter3Projections.lean#L242)<br><code>residual X y = annihilatorMatrix X *ᵥ y</code> |
 | Section 3.14 fitted values and residuals are orthogonal | $\hat{Y}' \hat{e} = 0$ | [fitted_dot_residual](../../HansenEconometrics/Chapter3Projections.lean#L249)<br><code>fitted X y ⬝ᵥ residual X y = 0</code> |
 | Section 3.14 Pythagorean decomposition | $Y'Y = \hat{Y}'\hat{Y} + \hat{e}'\hat{e}$ | [fitted_residual_pythagorean](../../HansenEconometrics/Chapter3Projections.lean#L259)<br><code>y ⬝ᵥ y = fitted X y ⬝ᵥ fitted X y + residual X y ⬝ᵥ residual X y</code> |
-| Theorem 3.4 partitioned coefficient formulae | $\hat{\beta}_1,\hat{\beta}_2$ as functions of partitioned moments |  |
-| Theorem 3.5 coefficient equivalence | $\hat{\beta}_2 = (X_2' M_1 X_2)^{-1} X_2' M_1 Y$ | [fromColsRightBeta_eq_fwlBeta](../../HansenEconometrics/Chapter3FWL.lean#L147)<br><code>fromColsRightBeta X₁ X₂ y = fwlBeta X₁ X₂ y</code> |
+| Theorem 3.4 partitioned coefficient formulae | $\hat{\beta}_1 = (X_1' M_2 X_1)^{-1} X_1' M_2 Y$ (Eq. 3.37); $\hat{\beta}_2 = (X_2' M_1 X_2)^{-1} X_2' M_1 Y$ (Eq. 3.38) | [fromColsLeftBeta_eq_partitioned_form](../../HansenEconometrics/Chapter3FWL.lean#L277)<br>[fromColsRightBeta_eq_partitioned_form](../../HansenEconometrics/Chapter3FWL.lean#L232) |
+| Theorem 3.5 coefficient equivalence (FWL) | $\hat{\beta}_2 = \hat{\beta}(M_1 X_2, M_1 Y)$ | [fromColsRightBeta_eq_fwlBeta](../../HansenEconometrics/Chapter3FWL.lean#L147)<br><code>fromColsRightBeta X₁ X₂ y = fwlBeta X₁ X₂ y</code> |
 | Theorem 3.5 residual equivalence | $\hat{e}_{\text{full}} = M_{M_1 X_2} M_1 Y$ | [fwl_residual_eq_full_residual](../../HansenEconometrics/Chapter3FWL.lean#L163)<br><code>residual (residualizedRegressors X₁ X₂) (annihilatorMatrix X₁ *ᵥ y) = residual (Matrix.fromCols X₁ X₂) y</code> |
 
 ## Lean-only bridge results
@@ -127,10 +128,9 @@ not surfaced here.
 
 ## Notes
 
-- Theorem 3.4 is still intentionally blank: it is one of the main remaining Chapter 3
-  theorem labels not yet wrapped in the current Lean layer. Theorem 3.1 is fully landed
-  (existence half via `sumSquaredErrors_olsBeta_le` / `olsBeta_isMinOn`; uniqueness via
-  `olsBeta_eq_of_minimizer`).
+- Theorems 3.1, 3.2, 3.3, 3.4, and 3.5 are all fully landed. The remaining Chapter 3
+  textbook content is leverage / leave-one-out (Sections 3.20–3.21) and centered
+  analysis-of-variance / R² (Section 3.14 follow-on).
 - Several Lean helper results in the projection file are stronger than the textbook labels because
   they package reusable matrix facts such as rank and Hermitian structure.
 - The projection-rank helper [rank_hatMatrix](../../HansenEconometrics/Chapter3Projections.lean#L174)

--- a/inventory/ch3-inventory.md
+++ b/inventory/ch3-inventory.md
@@ -111,7 +111,7 @@ Conventions:
 | Section 3.14 Pythagorean decomposition | $Y'Y = \hat{Y}'\hat{Y} + \hat{e}'\hat{e}$ | [fitted_residual_pythagorean](../../HansenEconometrics/Chapter3Projections.lean#L259)<br><code>y ⬝ᵥ y = fitted X y ⬝ᵥ fitted X y + residual X y ⬝ᵥ residual X y</code> |
 | Theorem 3.4 partitioned coefficient formulae | $\hat{\beta}_1 = (X_1' M_2 X_1)^{-1} X_1' M_2 Y$ (Eq. 3.37); $\hat{\beta}_2 = (X_2' M_1 X_2)^{-1} X_2' M_1 Y$ (Eq. 3.38) | [fromColsLeftBeta_eq_partitioned_form](../../HansenEconometrics/Chapter3FWL.lean#L277)<br>[fromColsRightBeta_eq_partitioned_form](../../HansenEconometrics/Chapter3FWL.lean#L232) |
 | Theorem 3.5 coefficient equivalence (FWL) | $\hat{\beta}_2 = \hat{\beta}(M_1 X_2, M_1 Y)$ | [fromColsRightBeta_eq_fwlBeta](../../HansenEconometrics/Chapter3FWL.lean#L147)<br><code>fromColsRightBeta X₁ X₂ y = fwlBeta X₁ X₂ y</code> |
-| Theorem 3.5 residual equivalence | $\hat{e}_{\text{full}} = M_{M_1 X_2} M_1 Y$ | [fwl_residual_eq_full_residual](../../HansenEconometrics/Chapter3FWL.lean#L163)<br><code>residual (residualizedRegressors X₁ X₂) (annihilatorMatrix X₁ *ᵥ y) = residual (Matrix.fromCols X₁ X₂) y</code> |
+| Theorem 3.5 residual equivalence | $\hat{e}_{\text{full}} = M_{M_1 X_2} M_1 Y$ | [fwl_residual_eq_full_residual](../../HansenEconometrics/Chapter3FWL.lean#L319)<br><code>residual (residualizedRegressors X₁ X₂) (annihilatorMatrix X₁ *ᵥ y) = residual (Matrix.fromCols X₁ X₂) y</code> |
 
 ## Lean-only bridge results
 


### PR DESCRIPTION
## Summary

Formalizes Hansen's Theorem 3.4 — the partitioned coefficient formulae for the OLS regression on `[X₁ X₂]`. Proves both equations:

- **β̂₁ = (X₁' M₂ X₁)⁻¹ X₁' M₂ Y** (Hansen Eq. 3.37) — `fromColsLeftBeta_eq_partitioned_form`
- **β̂₂ = (X₂' M₁ X₂)⁻¹ X₂' M₁ Y** (Hansen Eq. 3.38) — `fromColsRightBeta_eq_partitioned_form`

where M₁ and M₂ are the residual-maker matrices for X₁ and X₂.

The repo previously had `fromColsRightBeta_eq_fwlBeta` (Theorem 3.5 coefficient identity), which gives β̂₂ in residualization form. This PR adds the explicit Hansen-form for both blocks, plus the symmetric companion identity for β̂₁.

## What's added

In `HansenEconometrics/Chapter3FWL.lean`:

- `fromColsLeftBeta_eq_partitioned_form` — Hansen Eq. 3.37, the explicit closed-form for β̂₁.
- `fromColsRightBeta_eq_partitioned_form` — Hansen Eq. 3.38, the explicit closed-form for β̂₂.
- `fromColsLeftBeta_eq_fwlBeta` — symmetric companion to the existing `fromColsRightBeta_eq_fwlBeta`. Together they say: `fromColsRightBeta X₁ X₂ y = fwlBeta X₁ X₂ y` (X₁ residualizes X₂) and `fromColsLeftBeta X₁ X₂ y = fwlBeta X₂ X₁ y` (X₂ residualizes X₁).
- Two supporting auxiliary lemmas mirroring the existing right-block FWL infrastructure with X₁ ↔ X₂: `fwl_auxiliary_residual_eq_annihilator_full_residual_left` and `fwl_fromColsLeftBeta_normal_equations`.

## Why route through the existing FWL infrastructure

The existing `fromColsRightBeta_eq_fwlBeta` (Theorem 3.5 coefficient identity) already proves β̂₂ = `olsBeta (M₁X₂) (M₁Y)`, which is the residualization form of Eq. 3.38. The Hansen-form theorem unfolds this and applies M₁'s symmetry (`annihilatorMatrix_transpose`) and idempotence (`annihilatorMatrix_idempotent`) to collapse `(M₁X₂)' (M₁X₂)` to `X₂' M₁ X₂` and `(M₁X₂)' (M₁Y)` to `X₂' M₁ Y`.

For β̂₁, no equivalent identity existed; this PR adds it by mirroring the existing right-block FWL machinery with X₁ ↔ X₂ swapped.

## Hypothesis-stack design

Each Hansen-form theorem (`fromColsRightBeta_eq_partitioned_form` and `fromColsLeftBeta_eq_partitioned_form`) takes 3 `Invertible` instances:

- `[Invertible (X₁ᵀ * X₁)]` (or `[Invertible (X₂ᵀ * X₂)]` for the symmetric one)
- `[Invertible ((Matrix.fromCols X₁ X₂)ᵀ * Matrix.fromCols X₁ X₂)]`
- `[Invertible (X₂ᵀ * annihilatorMatrix X₁ * X₂)]` (or the symmetric one)

The fourth instance one might expect — for the residualized-Gram form `(M₁X₂)' (M₁X₂)` — is derived inside the proof via `Invertible.copy` (`Mathlib/Algebra/Group/Invertible/Defs.lean:190`) once the proof's `hquad` identity equating the two underlying matrices is established. The typeclass-distinct `Invertible` instances on these propositionally-equal matrices are then bridged via `Matrix.invOf_eq_nonsing_inv` to allow rewriting under `⅟`.

This design matches Hansen's hypothesis stack more naturally — the residualized-Gram nonsingularity is a derived consequence, not a primitive — and reduces the public API surface for downstream consumers.

## Inventory updates

- The Theorem 3.4 row in the main Crosswalk table is populated with both Lean theorem links (was previously blank).
- **The Theorem 3.5 row's LaTeX is corrected.** Previously it carried `\hat{\beta}_2 = (X_2' M_1 X_2)^{-1} X_2' M_1 Y` — but that LaTeX is Hansen Eq. 3.38 (Theorem 3.4 content), not Theorem 3.5. Theorem 3.5's actual content is the FWL identity. Without this fix, after this PR landed the inventory would have had the same LaTeX in two rows under different theorem labels (Theorem 3.4 vs Theorem 3.5).
- Chapter status block, Immediate target, and Notes block all updated to reflect Theorems 3.1–3.5 as fully landed.

## Verification

- `lake build` exits 0 with `Build completed successfully (3128 jobs)`.
- `Chapter3FWL.lean` compiles ✔ (clean, no linter warnings on this PR's diff).