### PR TITLE
Add Lean CI lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Lean CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  build-and-lint:
+    name: Build and lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build Lean project
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: true
+          lint: false
+          test: false
+          use-mathlib-cache: true
+
+      - name: Build Mathlib text-style linter
+        run: lake build @mathlib/lint-style
+
+      - name: Run Mathlib text-style linter
+        run: lake env .lake/packages/mathlib/.lake/build/bin/lint-style --github HansenEconometrics

--- a/.github/workflows/full-build-tags.yml
+++ b/.github/workflows/full-build-tags.yml
@@ -1,0 +1,27 @@
+name: Full Lean build on selected tags
+
+on:
+  push:
+    tags:
+      - 'full-build-*'
+      - 'release-*'
+  workflow_dispatch:
+
+jobs:
+  full-build:
+    name: Full lake build
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Full lake build
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: true
+          lint: false
+          test: false
+          use-mathlib-cache: true

--- a/README.md
+++ b/README.md
@@ -42,6 +42,40 @@ In practice this means we will often restate Hansen’s results in more Lean-nat
 - `HansenEconometrics.lean` — root imports
 - `lakefile.toml`, `lake-manifest.json`, `lean-toolchain` — Lean project config
 
+## CI and local linting
+
+Every pull request is gated by `.github/workflows/ci.yml`, which runs:
+
+```sh
+lake build
+lake build @mathlib/lint-style
+lake env .lake/packages/mathlib/.lake/build/bin/lint-style --github HansenEconometrics
+```
+
+The first command builds the project. The final two commands build and run
+Mathlib's text-style linter against the root `HansenEconometrics` module, so
+style lints gate the PR alongside the build. The repository already enables
+`weak.linter.mathlibStandardSet = true` in `lakefile.toml`, so Lean's
+elaboration linters run during builds; existing warnings currently keep the CI
+from using `lake build --wfail` as a hard gate.
+
+For a local pre-push check, run the same commands without `--github` for more
+readable output:
+
+```sh
+lake build
+lake build @mathlib/lint-style
+lake env .lake/packages/mathlib/.lake/build/bin/lint-style HansenEconometrics
+```
+
+A separate `.github/workflows/full-build-tags.yml` workflow runs a full
+`lake build` only for selected tag patterns (`full-build-*` and `release-*`) or
+manual dispatch. This is feasible for expensive validation runs because it
+avoids charging every PR/push twice while still allowing release-style tags to
+request a full clean CI build with Lean/Mathlib cache support. Once the current
+Lean warnings are cleaned up, that workflow can be tightened to
+`lake build --wfail`.
+
 ## Chapter progress
 
 Legend:

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@ decls_json := "site/_generated/declarations.json"
 # Default: render the site (walkthroughs only — auto-stub layer is paused).
 default: site-render
 
+# Local equivalent of the PR Lean CI gate.
+ci:
+    lake build
+    lake build @mathlib/lint-style
+    lake env .lake/packages/mathlib/.lake/build/bin/lint-style HansenEconometrics
+
 # Run lake exe export_decls and write declarations.json.
 # Only needed for the full-coverage build (`site-full`).
 site-export:

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -1,0 +1,2 @@
+-- Manual exceptions for Mathlib's text-style linter.
+-- Keep this empty unless a deliberate, reviewed exception is needed.


### PR DESCRIPTION
## Summary
- add a PR/push Lean CI workflow that runs `lake build` and Mathlib's text-style linter
- document the local pre-push lint/build commands and add a `just ci` helper
- add a selected-tag full-build workflow for expensive validation runs

## Tag full-build feasibility
Running a full `lake build` on specific git tags is feasible with GitHub Actions tag filters. This PR adds `.github/workflows/full-build-tags.yml`, triggered only by `full-build-*` and `release-*` tags (plus manual dispatch), so expensive clean builds can be requested deliberately rather than on every PR/push. `leanprover/lean-action` uses the Lean/Mathlib cache path to keep those runs tractable.

I did not set `--wfail` yet because the current tree emits existing Lean/Mathlib linter warnings under `lake build --wfail`; once those are cleaned up, the tag workflow and main CI can be tightened to `lake build --wfail`.

Closes #29

## Validation
- `lake build`
- `lake build @mathlib/lint-style`
- `lake env .lake/packages/mathlib/.lake/build/bin/lint-style HansenEconometrics`
- Ruby YAML parse of both new workflow files
