### PR TITLE
Add CIA potential outcomes bridge

### DIFF
--- a/HansenEconometrics/Chapter2PotentialOutcomes.lean
+++ b/HansenEconometrics/Chapter2PotentialOutcomes.lean
@@ -1,3 +1,4 @@
+import Mathlib.Probability.Independence.Conditional
 import HansenEconometrics.Chapter2CondExp
 
 /-!
@@ -82,6 +83,100 @@ def TreatmentMeanIndependentOn
     (μ : Measure Ω) (Y0 Y1 : Ω → ℝ) (D : Ω → Bool) (X : Ω → β) : Prop :=
   condExpOn μ Y0 (fun ω => (D ω, X ω)) =ᵐ[μ] condExpOn μ Y0 X ∧
     condExpOn μ Y1 (fun ω => (D ω, X ω)) =ᵐ[μ] condExpOn μ Y1 X
+
+/-- Hansen Definition 2.9, variable-facing conditional independence assumption.
+
+This package records the conditional independence of treatment and each potential outcome after
+conditioning on covariates, together with the measurability and integrability hypotheses needed to
+turn that conditional-independence statement into the mean-independence bridge used by the CATE
+theorems below. -/
+structure PotentialOutcomeCIAOn
+    [StandardBorelSpace Ω] (μ : Measure Ω) [IsFiniteMeasure μ]
+    (Y0 Y1 : Ω → ℝ) (D : Ω → Bool) (X : Ω → β) : Prop where
+  /-- Covariates are measurable. -/
+  x_measurable : Measurable X
+  /-- Treatment is measurable. -/
+  d_measurable : Measurable D
+  /-- Untreated potential outcome is measurable. -/
+  y0_measurable : Measurable Y0
+  /-- Treated potential outcome is measurable. -/
+  y1_measurable : Measurable Y1
+  /-- Untreated potential outcome is integrable. -/
+  y0_integrable : Integrable Y0 μ
+  /-- Treated potential outcome is integrable. -/
+  y1_integrable : Integrable Y1 μ
+  /-- Treatment and the untreated potential outcome are conditionally independent given `X`. -/
+  condIndep_y0 : D ⟂ᵢ[X, x_measurable; μ] Y0
+  /-- Treatment and the treated potential outcome are conditionally independent given `X`. -/
+  condIndep_y1 : D ⟂ᵢ[X, x_measurable; μ] Y1
+
+omit [MeasurableSpace Ω] in
+theorem conditioningSpace_pair_comm
+    {D : Ω → Bool} {X : Ω → β} :
+    conditioningSpace (fun ω => (D ω, X ω)) =
+      conditioningSpace (fun ω => (X ω, D ω)) := by
+  unfold conditioningSpace
+  change MeasurableSpace.comap (fun ω => (D ω, X ω))
+      ((inferInstance : MeasurableSpace Bool).prod (inferInstance : MeasurableSpace β)) =
+    MeasurableSpace.comap (fun ω => (X ω, D ω))
+      ((inferInstance : MeasurableSpace β).prod (inferInstance : MeasurableSpace Bool))
+  rw [MeasurableSpace.comap_prodMk, MeasurableSpace.comap_prodMk, sup_comm]
+
+private theorem condExpOn_covariate_treatment_eq_of_condIndep
+    [StandardBorelSpace Ω] [IsFiniteMeasure μ]
+    {Y : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hX : Measurable X) (hD : Measurable D) (hYmeas : Measurable Y)
+    (hYint : Integrable Y μ)
+    (hcond : D ⟂ᵢ[X, hX; μ] Y) :
+    condExpOn μ Y (fun ω => (X ω, D ω)) =ᵐ[μ] condExpOn μ Y X := by
+  have hpair : Measurable (fun ω => (X ω, D ω)) := hX.prod hD
+  have hkernel_map :
+      condDistrib Y (fun ω => (X ω, D ω)) μ =ᵐ[μ.map (fun ω => (X ω, D ω))]
+        (condDistrib Y X μ).prodMkRight Bool := by
+    exact (condIndepFun_iff_condDistrib_prod_ae_eq_prodMkRight
+      (f := Y) (g := D) (k := X) hYmeas hD hX).mp hcond
+  have hkernel :
+      ∀ᵐ ω ∂μ, condDistrib Y (fun ω => (X ω, D ω)) μ (X ω, D ω) =
+        (condDistrib Y X μ).prodMkRight Bool (X ω, D ω) :=
+    ae_of_ae_map hpair.aemeasurable hkernel_map
+  have hpair_ce :
+      condExpOn μ Y (fun ω => (X ω, D ω)) =ᵐ[μ]
+        fun ω => ∫ y, y ∂condDistrib Y (fun ω => (X ω, D ω)) μ (X ω, D ω) := by
+    simpa [condExpOn, conditioningSpace] using
+      (condExp_ae_eq_integral_condDistrib'
+        (X := fun ω => (X ω, D ω)) (Y := Y) (μ := μ) hpair hYint)
+  have hX_ce :
+      condExpOn μ Y X =ᵐ[μ]
+        fun ω => ∫ y, y ∂condDistrib Y X μ (X ω) := by
+    simpa [condExpOn, conditioningSpace] using
+      (condExp_ae_eq_integral_condDistrib'
+        (X := X) (Y := Y) (μ := μ) hX hYint)
+  have hintegral :
+      (fun ω => ∫ y, y ∂condDistrib Y (fun ω => (X ω, D ω)) μ (X ω, D ω)) =ᵐ[μ]
+        fun ω => ∫ y, y ∂condDistrib Y X μ (X ω) := by
+    filter_upwards [hkernel] with ω hω
+    rw [hω]
+    rfl
+  exact hpair_ce.trans (hintegral.trans hX_ce.symm)
+
+/-- Conditional independence of treatment and each potential outcome given `X` implies the
+mean-independence bridge used by the variable-facing CATE theorems. -/
+theorem PotentialOutcomeCIAOn.toTreatmentMeanIndependentOn
+    [StandardBorelSpace Ω] [IsFiniteMeasure μ]
+    {Y0 Y1 : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hcia : PotentialOutcomeCIAOn μ Y0 Y1 D X) :
+    TreatmentMeanIndependentOn μ Y0 Y1 D X := by
+  constructor
+  · have hXD := condExpOn_covariate_treatment_eq_of_condIndep
+      (μ := μ) (Y := Y0) (D := D) (X := X)
+      hcia.x_measurable hcia.d_measurable hcia.y0_measurable hcia.y0_integrable
+      hcia.condIndep_y0
+    simpa [condExpOn, conditioningSpace_pair_comm] using hXD
+  · have hXD := condExpOn_covariate_treatment_eq_of_condIndep
+      (μ := μ) (Y := Y1) (D := D) (X := X)
+      hcia.x_measurable hcia.d_measurable hcia.y1_measurable hcia.y1_integrable
+      hcia.condIndep_y1
+    simpa [condExpOn, conditioningSpace_pair_comm] using hXD
 
 /-- The average treatment effect is the difference in the means of the two potential outcomes.
 Hansen writes this quantity as `ACE`. -/
@@ -179,6 +274,41 @@ theorem conditionalAverageTreatmentEffectOn_treatment_covariates_eq_of_meanIndep
         (μ := μ) hmean).trans <|
         (conditionalAverageTreatmentEffectOn_eq_conditionalPotentialOutcomeContrastOn
           (μ := μ) (X := X) hY1 hY0).symm
+
+/-- CIA-facing version of the variable-conditioned potential-outcome contrast theorem.
+Conditional independence of treatment and potential outcomes given covariates implies that adding
+treatment to the conditioning variables does not change the potential-outcome contrast. -/
+theorem conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_of_CIA
+    [StandardBorelSpace Ω] [IsFiniteMeasure μ]
+    {Y0 Y1 : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hcia : PotentialOutcomeCIAOn μ Y0 Y1 D X) :
+    conditionalPotentialOutcomeContrastOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ]
+      conditionalPotentialOutcomeContrastOn μ Y0 Y1 X :=
+  conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_of_meanIndependent
+    (μ := μ) hcia.toTreatmentMeanIndependentOn
+
+/-- CIA-facing version of Hansen Theorem 2.12 at the variable/a.e. layer. Under conditional
+independence of treatment and potential outcomes given covariates, the treatment-and-covariate
+potential-outcome contrast equals the conditional average treatment effect. -/
+theorem conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_cate_of_CIA
+    [StandardBorelSpace Ω] [IsFiniteMeasure μ]
+    {Y0 Y1 : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hcia : PotentialOutcomeCIAOn μ Y0 Y1 D X) :
+    conditionalPotentialOutcomeContrastOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ]
+      conditionalAverageTreatmentEffectOn μ Y0 Y1 X :=
+  conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_cate_of_meanIndependent
+    (μ := μ) hcia.toTreatmentMeanIndependentOn hcia.y1_integrable hcia.y0_integrable
+
+/-- Direct CIA-facing CATE bridge for Hansen Theorem 2.12: under conditional independence,
+conditioning the treatment effect on `(D, X)` gives the same CATE as conditioning on `X` alone. -/
+theorem conditionalAverageTreatmentEffectOn_treatment_covariates_eq_of_CIA
+    [StandardBorelSpace Ω] [IsFiniteMeasure μ]
+    {Y0 Y1 : Ω → ℝ} {D : Ω → Bool} {X : Ω → β}
+    (hcia : PotentialOutcomeCIAOn μ Y0 Y1 D X) :
+    conditionalAverageTreatmentEffectOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ]
+      conditionalAverageTreatmentEffectOn μ Y0 Y1 X :=
+  conditionalAverageTreatmentEffectOn_treatment_covariates_eq_of_meanIndependent
+    (μ := μ) hcia.toTreatmentMeanIndependentOn hcia.y1_integrable hcia.y0_integrable
 
 end Probability
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Legend:
 | ch | title | status | notes |
 |---:|---|---|---|
 | 01 | Introduction | not started | text extracted and inventoried; mostly exposition |
-| 02 | Conditional Expectation and Projection | partial | conditional expectation, variance, and linear projection algebra completed |
+| 02 | Conditional Expectation and Projection | partial | conditional expectation, variance, linear projection algebra, and variable-facing potential-outcomes/CIA CATE wrappers completed |
 | 03 | The Algebra of Least Squares | partial | OLS algebra + projection/annihilator (incl. rank), leverage identities/bounds, reduced-Gram and literal row-deleted leave-one-out formulas, influence diagnostics, and FWL coefficient/residual core landed |
 | 04 | Least Squares Regression | partial | OLS/GLS algebra, unbiasedness, covariance identities, Gauss-Markov lower bounds, `s²` unbiasedness, HC2/HC3, and clustered covariance definitions/finite-sample adjustment landed |
 | 05 | Normal Regression | partial | multivariate-normal wrappers, normal-model scaffolding, finite-sample Gaussian/chi-square/Student-t/F laws, confidence intervals, and classical test results landed; Kinal moment threshold deferred |

--- a/inventory/ch2-inventory.md
+++ b/inventory/ch2-inventory.md
@@ -28,9 +28,9 @@ Current Lean coverage:
 - conditional variance / total variance package
 - best predictor theorem
 - population linear projection algebra through Theorems 2.9 and 2.10
-- initial potential-outcomes API for Section 2.30:
-  observed outcomes, individual/average/conditional treatment effects, and a mean-independence bridge
-  toward Theorem 2.12
+- potential-outcomes API for Section 2.30:
+  observed outcomes, individual/average/conditional treatment effects, a Mathlib `CondIndepFun` CIA
+  package, and variable-facing CATE bridges for Theorem 2.12
 
 Current strategy:
 - prove the strongest sigma-algebra or abstract statement first
@@ -38,8 +38,8 @@ Current strategy:
 - reuse Mathlib conditional-expectation and `L²` projection infrastructure where possible
 
 Next likely Chapter 2 targets:
-- strengthen the potential-outcomes layer from the mean-independence bridge to a full CIA theorem
-  using Mathlib conditional independence or regular conditional distributions
+- decide whether the pointwise density notation `ACE(x)` or a literal observed-regression derivative
+  `m(1,x)-m(0,x)` interface is worth adding on top of the current a.e. variable-facing CATE theorem
 - decide whether any remaining Chapter 2 results are worth formalizing before moving on
 
 ## Proof Architecture
@@ -99,7 +99,10 @@ Then prove:
 - **D2.6/D2.7** `ATE = E[Y(1)] - E[Y(0)]`
 - **D2.8** `CATE(X) = E[Y(1) | X] - E[Y(0) | X]`
 - `ATE = E[CATE(X)]` by the tower property
-- a mean-independence bridge toward **T2.12**:
+- a Mathlib conditional-independence package for **D2.9/CIA**:
+  if `D` is conditionally independent of each potential outcome given `X`, then the mean-independence
+  bridge follows by the conditional-distribution characterization
+- variable-facing **T2.12** bridges:
   if conditioning additionally on treatment does not change the potential-outcome conditional means,
   then the `(D, X)` potential-outcome contrast equals the CATE
 
@@ -278,12 +281,14 @@ Links:
 | $ACE = E[Y(1)-Y(0)]$ | <code>averageTreatmentEffect μ Y0 Y1</code> |
 | $ACE(X) = E[Y(1)-Y(0) \mid X]$ | <code>conditionalAverageTreatmentEffectOn μ Y0 Y1 X</code> |
 | CIA mean-independence consequence | <code>TreatmentMeanIndependentOn μ Y0 Y1 D X</code> |
+| Variable-facing CIA package | <code>PotentialOutcomeCIAOn μ Y0 Y1 D X</code> |
 
 Notes:
 - Hansen calls the population quantity the average causal effect, `ACE`. The Lean API uses the more
   common causal-inference name `averageTreatmentEffect`.
-- The current Lean layer is variable-facing and a.e.-based. It does not yet formalize the pointwise
-  density notation `ACE(x)` or the full CIA-to-mean-independence implication.
+- The current Lean layer is variable-facing and a.e.-based. It proves the CIA-to-mean-independence
+  implication through Mathlib's `CondIndepFun`/`condDistrib` layer, but it does not yet formalize the
+  pointwise density notation `ACE(x)`.
 
 ### T2.12 Conditional Average Causal Effects
 
@@ -296,11 +301,13 @@ Links:
 | $ACE = \int ACE(x) f(x)\,dx$ | <code>averageTreatmentEffect μ Y0 Y1 = ∫ ω, conditionalAverageTreatmentEffectOn μ Y0 Y1 X ω ∂μ</code> |
 | Under the mean-independence consequence of CIA, the treatment-and-covariate potential-outcome contrast equals CATE | <code>conditionalPotentialOutcomeContrastOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ] conditionalAverageTreatmentEffectOn μ Y0 Y1 X</code> |
 | Under the mean-independence consequence of CIA, CATE conditioned on treatment and covariates equals CATE conditioned on covariates | <code>conditionalAverageTreatmentEffectOn μ Y0 Y1 (fun ω => (D ω, X ω)) =ᵐ[μ] conditionalAverageTreatmentEffectOn μ Y0 Y1 X</code> |
+| Under CIA, the treatment-and-covariate potential-outcome contrast equals CATE | <code>conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_cate_of_CIA</code> |
+| Under CIA, CATE conditioned on treatment and covariates equals CATE conditioned on covariates | <code>conditionalAverageTreatmentEffectOn_treatment_covariates_eq_of_CIA</code> |
 
 Notes:
-- This is a first formal bridge toward Theorem 2.12, not the final theorem as written in Hansen.
-- The final pointwise theorem should probably use Mathlib's `CondIndepFun`/`condDistrib` layer and
-  explicit standard-Borel, integrability, and overlap assumptions.
+- The theorem is still variable-facing and a.e.-based rather than a pointwise density statement.
+- The literal observed-regression derivative interface `m(1,x)-m(0,x)` remains a possible wrapper if a
+  downstream chapter needs that exact notation.
 
 ## Lean-only Bridge Results
 
@@ -340,3 +347,9 @@ Hansen's notation and the Lean formalization.
   mean-independence bridge from conditioning on `(D, X)` to the CATE.
 - [`conditionalAverageTreatmentEffectOn_treatment_covariates_eq_of_meanIndependent`](../HansenEconometrics/Chapter2PotentialOutcomes.lean):
   direct CATE bridge from conditioning on `(D, X)` to conditioning on `X`.
+- [`PotentialOutcomeCIAOn.toTreatmentMeanIndependentOn`](../HansenEconometrics/Chapter2PotentialOutcomes.lean):
+  discharges the mean-independence bridge from conditional independence of treatment and potential
+  outcomes given covariates, using Mathlib's conditional-distribution characterization.
+- [`conditionalPotentialOutcomeContrastOn_treatment_covariates_eq_cate_of_CIA`](../HansenEconometrics/Chapter2PotentialOutcomes.lean) and
+  [`conditionalAverageTreatmentEffectOn_treatment_covariates_eq_of_CIA`](../HansenEconometrics/Chapter2PotentialOutcomes.lean):
+  CIA-facing variable/a.e. CATE bridges for Hansen Theorem 2.12.


### PR DESCRIPTION
## Summary
- add `PotentialOutcomeCIAOn` as a Mathlib `CondIndepFun` package for potential outcomes
- bridge CIA to `TreatmentMeanIndependentOn` through conditional distributions
- add CIA-facing CATE wrappers and refresh Chapter 2 docs/inventory

## Verification
- `lake env lean HansenEconometrics/Chapter2PotentialOutcomes.lean`
- `lake build`
- `git diff --check`
- `rg -n "^import Mathlib$" HansenEconometrics -g "*.lean"` (no matches)
- `lake exe shake --cfg ../mathlib4/scripts/noshake.json HansenEconometrics`

AGENTS.md gate: no broad `import Mathlib`; new import is narrow; chapter inventory updated. Stacked on #50; retarget to `main` after #50 merges.