### PR TITLE
Add Hansen Theorem 9.1: t-test asymptotic size

### DIFF
--- a/HansenEconometrics.lean
+++ b/HansenEconometrics.lean
@@ -24,3 +24,5 @@ import HansenEconometrics.Chapter5NormalRegression
 import HansenEconometrics.Chapter5LikelihoodRatioTest
 import HansenEconometrics.Chapter6Asymptotics
 import HansenEconometrics.Chapter7Asymptotics
+
+import HansenEconometrics.Chapter9HypothesisTesting

--- a/HansenEconometrics/Chapter9HypothesisTesting.lean
+++ b/HansenEconometrics/Chapter9HypothesisTesting.lean
@@ -1,0 +1,129 @@
+import HansenEconometrics.Chapter7Asymptotics.Inference
+
+/-!
+# Chapter 9 — Hypothesis Testing
+
+This file formalizes the asymptotic theory of hypothesis tests from Hansen's
+Chapter 9. The current public surface covers the asymptotic-size half of
+**Theorem 9.1** (t tests):
+
+* `tTest_rejectionProb_tendsto_of_abs_tstat` — the generic Chapter 9 size
+  bridge. If the absolute value of a sequence of test statistics converges in
+  distribution to `|N(0, 1)|`, then the rejection probability of the two-sided
+  test "reject if `|T| > c`" converges to the absolute-standard-normal mass of
+  `(c, ∞)`. This is the asymptotic-size half of Theorem 9.1, stated generically
+  so that every Chapter 9 t-test endpoint can reuse it. It is the
+  rejection-region counterpart of the Chapter 7 confidence-interval coverage
+  bridge `symmetricCI_coverage_of_abs_tstat`.
+* `olsHC0LinTTest_rejectionProb_tendsto` — Theorem 9.1's asymptotic-size half
+  for the ordinary-OLS HC0 t-test: the rejection probability of the two-sided
+  test converges to `P[|Z| > c]`. The hypotheses are the standard Chapter 7
+  robust-inference package, which is stronger than Hansen's bare Assumptions
+  7.2/7.3, and the null holds by construction (the t-statistic is centred at
+  the true coefficient). See the theorem's own docstring for the precise scope.
+
+The convergence half of Theorem 9.1 — `T(θ₀) →d N(0, 1)` under `H₀` — is
+already Hansen Theorem 7.11; see
+`olsHC0LinTStatOrZero_tendstoInDistribution_standardNormal` in
+`HansenEconometrics/Chapter7Asymptotics/Inference.lean`.
+
+Detailed theorem-by-theorem status lives in `inventory/ch9-inventory.md`.
+-/
+
+open MeasureTheory ProbabilityTheory Filter
+open scoped Matrix Real Topology ProbabilityTheory ENNReal
+
+namespace HansenEconometrics
+
+open Matrix
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω}
+variable {k : Type*} [Fintype k] [DecidableEq k]
+
+/-- The absolute standard-normal law has no atom at the frontier of `(c, ∞)`.
+
+The frontier of `Set.Ioi c` is the singleton `{c}`, exactly the frontier of
+`Set.Iic c`, so this reduces to `standardNormalAbs_frontier_Iic_null`. -/
+private theorem standardNormalAbs_frontier_Ioi_null (crit : ℝ) :
+    ((gaussianReal 0 1).map (fun x : ℝ => |x|)) (frontier (Set.Ioi crit)) = 0 := by
+  have hfr : frontier (Set.Ioi crit) = frontier (Set.Iic crit) := by
+    rw [frontier_Ioi, frontier_Iic]
+  rw [hfr]
+  exact standardNormalAbs_frontier_Iic_null crit
+
+/-- **Hansen Theorem 9.1, asymptotic size bridge for two-sided t tests.**
+
+If the absolute value of a sequence of test statistics `T` converges in
+distribution to `|N(0, 1)|`, then the probability of the rejection region
+`{|T| > c}` converges to the absolute-standard-normal mass of `(c, ∞)`.
+
+This is the asymptotic-size half of Hansen Theorem 9.1, stated generically over
+the test statistic so that the remaining Chapter 9 t-test endpoints can reuse
+it. It is the rejection-region counterpart of the Chapter 7 confidence-interval
+coverage bridge `symmetricCI_coverage_of_abs_tstat`. -/
+theorem tTest_rejectionProb_tendsto_of_abs_tstat
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {T : ℕ → Ω → ℝ} {crit : ℝ}
+    (hT : TendstoInDistribution (fun n ω => |T n ω|) atTop
+      (fun x : ℝ => |x|) (fun _ => μ) (gaussianReal 0 1)) :
+    Tendsto (fun n => μ {ω | crit < |T n ω|}) atTop
+      (𝓝 (((gaussianReal 0 1).map (fun x : ℝ => |x|)) (Set.Ioi crit))) := by
+  have h := TendstoInDistribution.tendsto_measure_preimage_of_null_frontier_real
+    hT (E := Set.Ioi crit) measurableSet_Ioi
+    (standardNormalAbs_frontier_Ioi_null crit)
+  simpa only [Set.mem_Ioi] using h
+
+/-- **Hansen Theorem 9.1, asymptotic-size half, for the ordinary-OLS HC0 t-test.**
+
+The two-sided HC0 t-test "reject if `|T| > c`" has asymptotic rejection
+probability equal to the absolute-standard-normal mass of `(c, ∞)` — that is,
+`P[|Z| > c] = 2(1 - Φ(c))` for `Z ∼ N(0, 1)`.
+
+Scope and faithfulness notes:
+* This formalizes only claim (b) of Hansen Theorem 9.1 (the rejection-probability
+  limit). Claim (a), `T(θ₀) →d N(0, 1)`, is Hansen Theorem 7.11 and is reused
+  via `olsHC0LinTStatOrZero_tendstoInDistribution_standardNormal`. Claim (c),
+  "the test has asymptotic size `α`", follows by choosing `c` with
+  `2(1 - Φ(c)) = α`, but is not separately stated.
+* The hypotheses are `RobustCovarianceConsistencyConditions` plus the
+  score-weight bounded-in-probability conditions. That package is documented as
+  *stronger* than Hansen's bare Assumption 7.2 (it adds iid-type conditions on
+  the score outer products); it is the standard Chapter 7 robust-inference
+  hypothesis stack, not a literal rendering of Assumptions 7.2/7.3.
+* The t-statistic is evaluated at the true coefficient vector `β`, so the null
+  `H₀ : θ = θ₀` holds by construction (`θ₀ = R'β`). The statement is therefore
+  Theorem 9.1's conclusion *under* `H₀`; it is not a decision rule that
+  discriminates `H₀` from an alternative. -/
+theorem olsHC0LinTTest_rejectionProb_tendsto
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → (k → ℝ)} {e : ℕ → Ω → ℝ} {y : ℕ → Ω → ℝ}
+    (h : RobustCovarianceConsistencyConditions μ X e) (β : k → ℝ)
+    (R : Matrix Unit k ℝ)
+    (hmodel : ∀ i ω, y i ω = (X i ω) ⬝ᵥ β + e i ω)
+    (hX_meas : ∀ i, AEStronglyMeasurable (X i) μ)
+    (he_meas : ∀ i, AEStronglyMeasurable (e i) μ)
+    (hCrossWeight : ∀ a b l : k, BoundedInProbability μ
+      (fun n ω =>
+        sampleScoreCovCrossWeight
+          (stackRegressors X n ω) (stackErrors e n ω) a b l))
+    (hQuadWeight : ∀ a b l m : k, BoundedInProbability μ
+      (fun n ω =>
+        sampleScoreCovQuadraticWeight
+          (stackRegressors X n ω) a b l m))
+    (hse_pos : 0 <
+      linearRestrictionStdError R (heteroAsymCov μ X e))
+    (crit : ℝ) :
+    Tendsto
+      (fun n => μ {ω | crit <
+        |olsLinearTStatOrZero R
+          (olsHetCovStar
+            (stackRegressors X n ω) (stackOutcomes y n ω))
+          (stackRegressors X n ω) (stackOutcomes y n ω) β
+          (Real.sqrt (n : ℝ))|})
+      atTop
+      (𝓝 (((gaussianReal 0 1).map (fun x : ℝ => |x|)) (Set.Ioi crit))) :=
+  tTest_rejectionProb_tendsto_of_abs_tstat
+    (olsHC0LinTStatOrZero_abs_tendstoInDistribution_standardNormalAbs
+      h β R hmodel hX_meas he_meas hCrossWeight hQuadWeight hse_pos)
+
+end HansenEconometrics

--- a/inventory/ch9-inventory.md
+++ b/inventory/ch9-inventory.md
@@ -127,6 +127,12 @@ Conventions:
 | Theorem 9.10 | Under Assumptions 7.2, 7.3, 7.4, and θn = r (βn) = r0 + n−1/2h, |  |
 | Theorem 9.11 | Under Assumptions 7.2, 7.3, 7.4, and θn = r (βn) = θ0 + n−1/2h, |  |
 
+## Lean-only bridge results
+
+| Lean theorem | Role |
+| --- | --- |
+| [tTest_rejectionProb_tendsto_of_abs_tstat](../../HansenEconometrics/Chapter9HypothesisTesting.lean#L64) | Generic Chapter 9 asymptotic-size bridge: from an absolute-t-statistic distributional limit it derives the two-sided test's rejection-probability limit `P[|T| > c] → P[|Z| > c]`. The reusable engine behind the concrete OLS HC0 t-test endpoint, intended to back Theorems 9.2–9.11; the rejection-region counterpart of Chapter 7's `symmetricCI_coverage_of_abs_tstat`. |
+
 ## Notes
 
 - This is currently a theorem-surface map for the chapter; Lean cells stay blank until each

--- a/inventory/ch9-inventory.md
+++ b/inventory/ch9-inventory.md
@@ -91,7 +91,10 @@
 4. Add the needed measure/probability infrastructure before attempting the main stochastic theorem.
 
 ## Status
-- not started
+- Theorem 9.1's asymptotic-size half — the t-test rejection-probability limit — landed in
+  `HansenEconometrics/Chapter9HypothesisTesting.lean`. The convergence half is reused from
+  Chapter 7 (Theorem 7.11); the size-α corollary is not separately stated.
+- Theorems 9.2–9.11 are still pending.
 
 ## LaTeX / Lean Crosswalk
 
@@ -106,12 +109,13 @@ Conventions:
 ## Links
 
 - [Hansen excerpt](../textbook/ch09/ch9_excerpt.txt)
+- [Hypothesis-testing file](../../HansenEconometrics/Chapter9HypothesisTesting.lean)
 
 ## Crosswalk
 
 | Textbook result | Textbook statement | Lean theorem |
 | --- | --- | --- |
-| Theorem 9.1 | Under Assumptions 7.2, 7.3, and H0 |  |
+| Theorem 9.1 | Under Assumptions 7.2, 7.3 and H₀ : θ = θ₀ ∈ ℝ, T(θ₀) →d N(0,1); the two-sided t-test "reject if absolute t exceeds c" has asymptotic size 2(1−Φ(c)) | [olsHC0LinTTest_rejectionProb_tendsto](../../HansenEconometrics/Chapter9HypothesisTesting.lean#L97) — claim (b) only: the OLS HC0 t-test rejection-probability limit, via the generic bridge [tTest_rejectionProb_tendsto_of_abs_tstat](../../HansenEconometrics/Chapter9HypothesisTesting.lean#L64).<br>Hypotheses are the Chapter 7 robust-inference package, stronger than bare Assumptions 7.2/7.3; the null holds by construction.<br>Claim (a) `T(θ₀) →d N(0,1)` is reused from Chapter 7 (`olsHC0LinTStatOrZero_tendstoInDistribution_standardNormal`); claim (c) "asymptotic size α" is not separately stated. |
 | Theorem 9.2 | Under Assumptions 7.2, 7.3, 7.4, andH0 |  |
 | Theorem 9.3 | Under Assumptions 7.2 and 7.3, E |  |
 | Theorem 9.4 | Under Assumptions 7.2, 7.3, 7.4, and H0 |  |
@@ -125,5 +129,15 @@ Conventions:
 
 ## Notes
 
-- This is currently a theorem-surface map for the chapter.
-- The Lean column is intentionally left blank until there is actual formalization to link.
+- This is currently a theorem-surface map for the chapter; Lean cells stay blank until each
+  result lands.
+- The Theorem 9.1 row formalizes only claim (b), the rejection-probability limit. Claim (a)
+  (`T(θ₀) →d N(0,1)`) is Hansen Theorem 7.11, reused from Chapter 7 rather than reproved;
+  claim (c) ("asymptotic size α") follows immediately but is not a separate declaration.
+- The hypotheses are the Chapter 7 robust-inference package
+  (`RobustCovarianceConsistencyConditions` plus score-weight conditions), documented there as
+  stronger than Hansen's bare Assumptions 7.2/7.3. The null is encoded by construction (the
+  t-statistic is centred at the true coefficient), so the statement is the conclusion under `H₀`.
+- `tTest_rejectionProb_tendsto_of_abs_tstat` is the generic rejection-probability bridge intended
+  to back the remaining Chapter 9 t-test endpoints, mirroring Chapter 7's
+  `symmetricCI_coverage_of_abs_tstat`.


### PR DESCRIPTION
New Chapter 9 module formalizing the **asymptotic-size half of Hansen Theorem 9.1**
(t tests) — the first Lean code for Chapter 9. Part of #70.

## What's added

`HansenEconometrics/Chapter9HypothesisTesting.lean` (new module):

- **`tTest_rejectionProb_tendsto_of_abs_tstat`** — generic Chapter 9 size bridge: if the absolute t-statistic converges in distribution to `|N(0,1)|`, the two-sided test's rejection probability `P[|T| > c]` converges to `P[|Z| > c]`. The reusable engine for the remaining Chapter 9 t-test endpoints; the rejection-region counterpart of Chapter 7's `symmetricCI_coverage_of_abs_tstat`.
- **`olsHC0LinTTest_rejectionProb_tendsto`** — Theorem 9.1's asymptotic-size statement for the ordinary-OLS HC0 t-test.
- `standardNormalAbs_frontier_Ioi_null` — private supporting lemma (the `|N(0,1)|` law gives zero mass to the frontier of `(c, ∞)`), reducing to Chapter 7's `standardNormalAbs_frontier_Iic_null`.

Registers the module import in `HansenEconometrics.lean` and updates `inventory/ch9-inventory.md` (Theorem 9.1 crosswalk row, a `Lean-only bridge results` entry, Status, and Notes).

## Scope and faithfulness

Hansen Theorem 9.1 has three claims: (a) `T(θ₀) →d N(0,1)`; (b) the rejection-probability limit `→ 2(1−Φ(c))`; (c) the test has asymptotic size α. This PR is deliberately scoped to **claim (b)**:

- **Claim (a)** is Hansen Theorem 7.11 — reused from Chapter 7 (`olsHC0LinTStatOrZero_tendstoInDistribution_standardNormal`), not reproved.
- **Claim (c)** follows immediately by choosing `c` with `2(1−Φ(c)) = α`; it is not separately stated.
- **Hypotheses**: `olsHC0LinTTest_rejectionProb_tendsto` uses `RobustCovarianceConsistencyConditions` plus the score-weight conditions — the standard Chapter 7 robust-inference package, documented there as *stronger* than Hansen's bare Assumption 7.2. The docstrings and inventory state this rather than claiming a literal Assumptions 7.2/7.3 rendering.
- **Null encoding**: the t-statistic is evaluated at the true coefficient `β`, so `H₀ : θ = θ₀` holds by construction — this formalizes Theorem 9.1's conclusion *under* `H₀`, consistent with how Chapter 7's t/CI theorems are encoded.

## AGENTS.md PR gate

- Reuses Mathlib + Chapter 7 (the t-statistic CMTs, the portmanteau bridge, `standardNormalAbs_frontier_Iic_null`) — no reproved infrastructure.
- One narrow project import (`Chapter7Asymptotics.Inference`), confirmed minimal by `lake exe shake`.
- Same-file scaffolding (`standardNormalAbs_frontier_Ioi_null`) is `private`.
- Module docstring present; `inventory/ch9-inventory.md` crosswalk row, `Lean-only bridge results` section, Status, and Notes updated.

## Verification

- `lake build` → `Build completed successfully (3173 jobs)`, no warnings on the new file.
- `lake exe shake` → clean (no project import suggestions).
- `grep -rn "sorry\|admit" HansenEconometrics/ --include="*.lean"` → no results.
- Diff — 3 files: - `HansenEconometrics/Chapter9HypothesisTesting.lean` +129 (new) - `HansenEconometrics.lean` +2 (import) - `inventory/ch9-inventory.md` +24/-4